### PR TITLE
feat: Allow using promises for token config

### DIFF
--- a/src/account/accountService.ts
+++ b/src/account/accountService.ts
@@ -83,7 +83,7 @@ export const fetchProfile = async (
 // TODO: this is a temporary solution to get the user's email address,
 // the API should have a account query to get the logged in user data
 export const fetchUser = async () => {
-  const email = getUserEmail();
+  const email = await getUserEmail();
   return fetchProfile(null, email === undefined ? null : { email });
 };
 

--- a/src/account/accountSlice.ts
+++ b/src/account/accountSlice.ts
@@ -17,7 +17,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import _ from 'lodash/fp';
 import * as accountService from 'terraso-client-shared/account/accountService';
-import { getToken, removeToken } from 'terraso-client-shared/account/auth';
+import { removeToken } from 'terraso-client-shared/account/auth';
+import { getAPIConfig } from 'terraso-client-shared/config';
 import logger from 'terraso-client-shared/monitoring/logger';
 import type { SharedDispatch } from 'terraso-client-shared/store/store';
 import { createAsyncThunk } from 'terraso-client-shared/store/utils';
@@ -35,7 +36,7 @@ const initialState = {
     urls: {},
     fetching: true,
   },
-  hasToken: false,
+  hasToken: getAPIConfig().tokenStorage.initialToken !== null,
   preferences: {
     saving: false,
     success: false,
@@ -56,11 +57,6 @@ export type User = {
   profileImage: string;
   preferences: Record<string, string>;
 };
-
-export const getInitialToken = createAsyncThunk(
-  'account/getInitialToken',
-  getToken
-);
 
 export const fetchUser = createAsyncThunk(
   'account/fetchUser',
@@ -111,16 +107,6 @@ export const userSlice = createSlice({
   },
 
   extraReducers: builder => {
-    builder.addCase(getInitialToken.fulfilled, (state, action) => ({
-      ...state,
-      hasToken: !!action.payload,
-    }));
-
-    builder.addCase(getInitialToken.rejected, state => ({
-      ...state,
-      hasToken: initialState.hasToken,
-    }));
-
     builder.addCase(saveUser.pending, state => ({
       ...state,
       currentUser: {

--- a/src/account/accountSlice.ts
+++ b/src/account/accountSlice.ts
@@ -35,7 +35,7 @@ const initialState = {
     urls: {},
     fetching: true,
   },
-  hasToken: !!getToken(),
+  hasToken: false,
   preferences: {
     saving: false,
     success: false,
@@ -56,6 +56,11 @@ export type User = {
   profileImage: string;
   preferences: Record<string, string>;
 };
+
+export const getInitialToken = createAsyncThunk(
+  'account/getInitialToken',
+  getToken
+);
 
 export const fetchUser = createAsyncThunk(
   'account/fetchUser',
@@ -106,6 +111,16 @@ export const userSlice = createSlice({
   },
 
   extraReducers: builder => {
+    builder.addCase(getInitialToken.fulfilled, (state, action) => ({
+      ...state,
+      hasToken: !!action.payload,
+    }));
+
+    builder.addCase(getInitialToken.rejected, state => ({
+      ...state,
+      hasToken: initialState.hasToken,
+    }));
+
     builder.addCase(saveUser.pending, state => ({
       ...state,
       currentUser: {

--- a/src/account/auth.ts
+++ b/src/account/auth.ts
@@ -24,8 +24,8 @@ type AccessToken = {
 
 export const getToken = () => getAPIConfig().tokenStorage.getToken('atoken');
 
-export const getAuthHeaders = (): Record<string, string> => {
-  const token = getToken();
+export const getAuthHeaders = async (): Promise<Record<string, string>> => {
+  const token = await getToken();
   if (!token) {
     return {};
   }
@@ -40,13 +40,14 @@ export const removeToken = () => {
 };
 
 export const refreshToken = async () => {
+  const refreshToken = await getAPIConfig().tokenStorage.getToken('rtoken');
   const response = await fetch(
     new URL('/auth/tokens', getAPIConfig().terrasoAPIURL).href,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        refresh_token: getAPIConfig().tokenStorage.getToken('rtoken'),
+        refresh_token: refreshToken,
       }),
     }
   );
@@ -63,7 +64,7 @@ export const refreshToken = async () => {
   getAPIConfig().tokenStorage.setToken('atoken', atoken);
 };
 
-export const getUserEmail = () => {
-  const token = getToken();
+export const getUserEmail = async () => {
+  const token = await getToken();
   return token === undefined ? undefined : jwt<AccessToken>(token).email;
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export type TerrasoAPIConfig = {
   terrasoAPIURL: string;
   graphQLEndpoint: string;
   tokenStorage: {
-    getToken: (name: string) => string | undefined;
+    getToken: (name: string) => Promise<string | undefined>;
     setToken: (name: string, token: string) => void;
     removeToken: (name: string) => void;
   };
@@ -24,6 +24,7 @@ export const { getAPIConfig, setAPIConfig } = (() => {
     },
     setAPIConfig: (config: TerrasoAPIConfig) => {
       apiConfig = config;
+      // initialize token
     },
   };
 })();

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,16 @@ export type TerrasoAPIConfig = {
     getToken: (name: string) => Promise<string | undefined>;
     setToken: (name: string, token: string) => void;
     removeToken: (name: string) => void;
+    /**
+     * Value of initial token used to init redux store.
+     * @remarks
+     * Redux requires a synchronous value to be passed to the store initial state.
+     * For environments where the token can be fetched synchronously, the token value
+     * can be passed. For environments where getToken is by default async, a null
+     * value should be provided. Application code is then responsible for initializing
+     * the token value on app startup.
+     */
+    initialToken: string | null;
   };
   logger: (severity: Severity, ...args: any[]) => void;
 };
@@ -24,7 +34,6 @@ export const { getAPIConfig, setAPIConfig } = (() => {
     },
     setAPIConfig: (config: TerrasoAPIConfig) => {
       apiConfig = config;
-      // initialize token
     },
   };
 })();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,26 +1,18 @@
 import type { Severity } from 'terraso-client-shared/monitoring/logger';
 
-type ConfigParams = {
-  usePromise: 'yes' | 'no';
-};
-
-type MaybePromise<T extends ConfigParams, V> = T['usePromise'] extends 'yes'
-  ? Promise<V>
-  : V;
-
-export type TerrasoAPIConfig<Params extends ConfigParams> = {
+export type TerrasoAPIConfig = {
   terrasoAPIURL: string;
   graphQLEndpoint: string;
   tokenStorage: {
-    getToken: (name: string) => MaybePromise<Params, string | undefined>;
-    setToken: (name: string, token: string) => MaybePromise<Params, void>;
-    removeToken: (name: string) => MaybePromise<Params, void>;
+    getToken: (name: string) => string | undefined;
+    setToken: (name: string, token: string) => void;
+    removeToken: (name: string) => void;
   };
   logger: (severity: Severity, ...args: any[]) => void;
 };
 
-export const { getAPIConfig, setAPIConfig } = (<T extends ConfigParams>() => {
-  let apiConfig: TerrasoAPIConfig<T> | undefined;
+export const { getAPIConfig, setAPIConfig } = (() => {
+  let apiConfig: TerrasoAPIConfig | undefined;
   return {
     getAPIConfig: () => {
       if (apiConfig === undefined) {
@@ -30,15 +22,8 @@ export const { getAPIConfig, setAPIConfig } = (<T extends ConfigParams>() => {
       }
       return apiConfig;
     },
-    setAPIConfig: (config: TerrasoAPIConfig<T>) => {
+    setAPIConfig: (config: TerrasoAPIConfig) => {
       apiConfig = config;
     },
   };
 })();
-
-export class APIConfig<T extends ConfigParams> {
-  config: TerrasoAPIConfig<T>;
-  constructor(config: TerrasoAPIConfig<T>) {
-    this.config = config;
-  }
-}

--- a/src/terrasoApi/api.ts
+++ b/src/terrasoApi/api.ts
@@ -130,12 +130,13 @@ export const request = async <T>({
   body: any;
   headers?: Record<string, string>;
 }): Promise<WithoutErrors<T>> => {
+  const authHeaders = await getAuthHeaders();
   const response = await fetch(
     new URL(path, getAPIConfig().terrasoAPIURL).href,
     {
       method: 'POST',
       headers: {
-        ...getAuthHeaders(),
+        ...authHeaders,
         ...headers,
       },
       body: body instanceof FormData ? body : JSON.stringify(body),

--- a/src/tests/config.ts
+++ b/src/tests/config.ts
@@ -6,7 +6,7 @@ setAPIConfig({
   terrasoAPIURL: 'http://127.0.0.1:8000',
   graphQLEndpoint: '/graphql',
   tokenStorage: {
-    getToken: () => undefined,
+    getToken: async () => undefined,
   } as any,
   logger: mockLogger,
 });


### PR DESCRIPTION
The mobile client needs to use Promises to fetch and store tokens, while the web client uses a synchronous Cookie API. In order to support both I changed the function type to return a Promise. It created a bit of difficulty with the Redux store; the initial state can't be set automatically because the getToken function is now async. It will mean that the client code will have to call the `getInitialToken` action on startup. We can maybe take another look at
this later.