### PR TITLE
chore: remove plausible-tracker node module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "jest": "^29.6.1",
         "jest-axe": "^8.0.0",
         "jest-environment-jsdom": "^29.6.1",
-        "plausible-tracker": "^0.3.8",
         "prettier": "^3.0.0",
         "stylelint": "^15.10.1",
         "stylelint-prettier": "^4.0.0",
@@ -12390,15 +12389,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/plausible-tracker": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.8.tgz",
-      "integrity": "sha512-lmOWYQ7s9KOUJ1R+YTOR3HrjdbxIS2Z4de0P/Jx2dQPteznJl2eX3tXxKClpvbfyGP59B5bbhW8ftN59HbbFSg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "jest": "^29.6.1",
     "jest-axe": "^8.0.0",
     "jest-environment-jsdom": "^29.6.1",
-    "plausible-tracker": "^0.3.8",
     "prettier": "^3.0.0",
     "stylelint": "^15.10.1",
     "stylelint-prettier": "^4.0.0",


### PR DESCRIPTION
## Description
Remove plausible-tracker node module. It's not used by `client-shared`.