### PR TITLE
chore: temporarily disable coverage check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,26 +53,26 @@ jobs:
       - name: Run test
         run: npm run test
 
-  tests-coverage:
-    runs-on: ubuntu-latest
+  # tests-coverage:
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.tool-versions'
-          cache: 'npm'
+  #     - name: Setup Node
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version-file: '.tool-versions'
+  #         cache: 'npm'
 
-      - name: Install dependencies
-        run: npm install
+  #     - name: Install dependencies
+  #       run: npm install
 
-      - name: Run test
-        run: npm run test-coverage
+  #     - name: Run test
+  #       run: npm run test-coverage
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
It fails every time and we merge anyway. Can be restored as part of completing #2.
