### PR TITLE
fix: don't run update-web and update-mobile on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
   update-web:
     needs: build
     uses: ./.github/workflows/update-shared.yml
+    if: github.event_name != 'pull_request'
     with:
       repo-path: 'techmatters/terraso-web-client'
       repo-ref: 'staging'
@@ -122,6 +123,7 @@ jobs:
   update-mobile:
     needs: build
     uses: ./.github/workflows/update-shared.yml
+    if: github.event_name != 'pull_request'
     with:
       repo-path: 'techmatters/terraso-mobile-client'
       repo-ref: 'main'


### PR DESCRIPTION
## Description
Don't run update-web and update-mobile on PR. These steps should only run on pushing to main.
