### PR TITLE
fix: remove extra npm install command abd GitHub action for commits

### DIFF
--- a/.github/workflows/update-shared.yml
+++ b/.github/workflows/update-shared.yml
@@ -43,9 +43,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}
-        run: |
-          npm install "github:techmatters/terraso-client-shared#${{ inputs.client-hash }}"
-          npm install
+        run: npm install "github:techmatters/terraso-client-shared#${{ inputs.client-hash }}"
 
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/update-shared.yml
+++ b/.github/workflows/update-shared.yml
@@ -48,9 +48,9 @@ jobs:
           npm install
 
       - name: Commit version bump
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@users.noreply.github.com"
-          git add -A
-          git commit -m "build: update shared client to ${{ inputs.client-hash }}"
-          git push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: "package.json package-lock.json"
+          commit_message "build: update shared client to ${{ inputs.client-hash }}"
+          commit_user_name: "GitHub Actions"
+          commit_user_email: actions@users.noreply.github.com

--- a/.github/workflows/update-shared.yml
+++ b/.github/workflows/update-shared.yml
@@ -51,6 +51,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           file_pattern: "package.json package-lock.json"
-          commit_message "build: update shared client to ${{ inputs.client-hash }}"
+          commit_message: "build: update shared client to ${{ inputs.client-hash }}"
           commit_user_name: "GitHub Actions"
           commit_user_email: actions@users.noreply.github.com


### PR DESCRIPTION
## Description
remove extra `npm install` command from GitHub Actions workflow for updating web client.

Use GitHub action for committing updated module.