### PR TITLE
fix: collapse site fields in project service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12983,8 +12983,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#8813449c8b2f4eb4b70b4add87007d2a93d25baa",
-      "integrity": "sha512-WXumMW1dnbEFfZjmNkRuibIuO7TDeRUQ8vr5K2nyhUs8bDZXUS67zM6TtLx92czO+PvdzI36ncH5abGHg3rpOQ=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#d87539e82c9ae59ace3948e1350f14ec25fedce4"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/src/project/projectService.ts
+++ b/src/project/projectService.ts
@@ -30,6 +30,7 @@ import type {
   Project,
   SerializableSet,
 } from 'terraso-client-shared/project/projectSlice';
+import { collapseSiteFields } from 'terraso-client-shared/site/siteService';
 import { Site } from 'terraso-client-shared/site/siteSlice';
 import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import {
@@ -66,7 +67,10 @@ const collapseProjectFields = collapseFields<
     sites: inp =>
       inp.siteSet.edges
         .map(edge => edge.node)
-        .reduce((x, y) => ({ ...x, [y.id]: y }), {} as Record<string, Site>),
+        .reduce(
+          (x, y) => ({ ...x, [y.id]: collapseSiteFields(y) }),
+          {} as Record<string, Site>,
+        ),
     memberships: inp =>
       inp.group.memberships.edges
         .map(({ node: { id, userRole, membershipStatus } }) => ({

--- a/src/site/siteService.ts
+++ b/src/site/siteService.ts
@@ -26,7 +26,7 @@ import type { Site } from 'terraso-client-shared/site/siteSlice';
 import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import { collapseConnectionEdges } from 'terraso-client-shared/terrasoApi/utils';
 
-const collapseSiteFields = (site: SiteDataFragment): Site => {
+export const collapseSiteFields = (site: SiteDataFragment): Site => {
   const { project, owner, ...rest } = site;
   return {
     ...rest,


### PR DESCRIPTION
## Description
The project service was updating user's sites with unprocessed `SiteNode`s from the graphql response. I think this error would've been caught by the compiler if the TypeScript type for `Site` had `projectId: string | null` and `ownerId: string | null` instead of `projectId?: string`, but then we would be forced to manually specify null everywhere when creating new sites. which isn't that common so might be a good trade-off. anyway i will file a separate issue for that, for now this is just the bug fix
