### PR TITLE
feat: Use Membership List in project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.2",
-        "terraso-backend": "github:techmatters/terraso-backend#2292702",
+        "terraso-backend": "github:techmatters/terraso-backend#4170565",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -12983,7 +12983,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#2292702340623e1da45620ef9dbc26a772cc38f4"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#4170565525a1b85462685d4e2c861a3cfeec7fba"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.2",
-        "terraso-backend": "github:techmatters/terraso-backend#d87539e",
+        "terraso-backend": "github:techmatters/terraso-backend#2292702",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -12983,7 +12983,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#d87539e82c9ae59ace3948e1350f14ec25fedce4"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#2292702340623e1da45620ef9dbc26a772cc38f4"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.2",
-    "terraso-backend": "github:techmatters/terraso-backend#2292702",
+    "terraso-backend": "github:techmatters/terraso-backend#4170565",
     "uuid": "^9.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.2",
-    "terraso-backend": "github:techmatters/terraso-backend#d87539e",
+    "terraso-backend": "github:techmatters/terraso-backend#2292702",
     "uuid": "^9.0.0"
   },
   "scripts": {

--- a/src/project/projectFragments.ts
+++ b/src/project/projectFragments.ts
@@ -47,7 +47,6 @@ export const projectData = /* GraphQL */ `
     updatedAt
     archived
     membershipList {
-      id
       ...projectMembershipList
     }
     siteSet {

--- a/src/project/projectFragments.ts
+++ b/src/project/projectFragments.ts
@@ -15,6 +15,29 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+export const projectMembershipFields = /* GraphQL */ `
+  fragment projectMembershipFields on ProjectMembershipNode {
+    id
+    userRole
+    user {
+      ...userFields
+    }
+  }
+`;
+
+export const projectMembershipList = /* GraphQL */ `
+  fragment projectMembershipList on ProjectMembershipListNode {
+    memberships {
+      totalCount
+      edges {
+        node {
+          ...projectMembershipFields
+        }
+      }
+    }
+  }
+`;
+
 export const projectData = /* GraphQL */ `
   fragment projectData on ProjectNode {
     id
@@ -23,9 +46,9 @@ export const projectData = /* GraphQL */ `
     description
     updatedAt
     archived
-    group {
+    membershipList {
       id
-      ...groupMembers
+      ...projectMembershipList
     }
     siteSet {
       edges {

--- a/src/project/projectService.ts
+++ b/src/project/projectService.ts
@@ -76,23 +76,6 @@ const collapseProjectFields = collapseFields<
           (x, y) => ({ ...x, [y.id]: collapseSiteFields(y) }),
           {} as Record<string, Site>,
         ),
-    memberships: inp =>
-      inp.membershipList.memberships?.edges
-        .map(({ node: { id, userRole, user } }) => ({
-          membershipId: id,
-          userId: user?.id,
-          userRole,
-        }))
-        .reduce(
-          (x, y) => {
-            if (y.userId !== undefined) {
-              let userId = y.userId;
-              return { ...x, [y.membershipId]: { ...y, userId } };
-            }
-            return x;
-          },
-          {} as Record<string, ProjectMembership>,
-        ) || {},
     users: inp =>
       inp.membershipList.memberships?.edges
         .map(({ node: { user } }) => {

--- a/src/project/projectService.ts
+++ b/src/project/projectService.ts
@@ -55,7 +55,7 @@ const collapseProjectFields = collapseFields<
               if (user === null || user === undefined) {
                 return x;
               }
-              return { ...x, [id]: { userId: user.id, userRole } };
+              return { ...x, [id]: { userId: user.id, userRole, id } };
             },
             {} as Record<string, ProjectMembership>,
           ) || {};

--- a/src/project/projectSlice.ts
+++ b/src/project/projectSlice.ts
@@ -17,10 +17,8 @@
 
 import { createAction, createSlice } from '@reduxjs/toolkit';
 import { setUsers, User } from 'terraso-client-shared/account/accountSlice';
-import {
-  Membership,
-  setMembers,
-} from 'terraso-client-shared/memberships/membershipsSlice';
+import { UserRole } from 'terraso-client-shared/graphqlSchema/graphql';
+import { setMembers } from 'terraso-client-shared/memberships/membershipsSlice';
 import * as projectService from 'terraso-client-shared/project/projectService';
 import { setSites, Site } from 'terraso-client-shared/site/siteSlice';
 import {
@@ -39,21 +37,25 @@ const { plural: dehydrateProjects, sing: dehydrateProject } = dehydrated<
 
 export type SerializableSet = Record<string, boolean>;
 
+export type ProjectMembership = {
+  userId: string;
+  userRole: UserRole;
+};
+
 export type Project = {
   id: string;
   name: string;
   privacy: 'PRIVATE' | 'PUBLIC';
   description: string;
   updatedAt: string; // this should be Date.toLocaleDateString; redux can't serialize Dates
-  membershipIds: Record<string, { user: string }>; // TODO: Why doesn't the membership have user info? have to store user id here as well
+  memberships: Record<string, ProjectMembership>;
   siteIds: SerializableSet;
-  groupId: string;
   archived: boolean;
 };
 
 export type HydratedProject = {
   dehydrated: Project;
-  memberships: Record<string, Membership>;
+  memberships: Record<string, ProjectMembership>;
   users: Record<string, User>;
   sites: Record<string, Site>;
 };

--- a/src/project/projectSlice.ts
+++ b/src/project/projectSlice.ts
@@ -38,6 +38,7 @@ export type SerializableSet = Record<string, boolean>;
 export type ProjectMembership = {
   userId: string;
   userRole: UserRole;
+  id: string;
 };
 
 export type Project = {

--- a/src/project/projectSlice.ts
+++ b/src/project/projectSlice.ts
@@ -18,7 +18,6 @@
 import { createAction, createSlice } from '@reduxjs/toolkit';
 import { setUsers, User } from 'terraso-client-shared/account/accountSlice';
 import { UserRole } from 'terraso-client-shared/graphqlSchema/graphql';
-import { setMembers } from 'terraso-client-shared/memberships/membershipsSlice';
 import * as projectService from 'terraso-client-shared/project/projectService';
 import { setSites, Site } from 'terraso-client-shared/site/siteSlice';
 import {
@@ -30,7 +29,6 @@ const { plural: dehydrateProjects, sing: dehydrateProject } = dehydrated<
   Project,
   HydratedProject
 >({
-  memberships: setMembers,
   users: setUsers,
   sites: setSites,
 });
@@ -55,7 +53,6 @@ export type Project = {
 
 export type HydratedProject = {
   dehydrated: Project;
-  memberships: Record<string, ProjectMembership>;
   users: Record<string, User>;
   sites: Record<string, Site>;
 };
@@ -139,7 +136,7 @@ const projectSlice = createSlice({
     builder.addCase(
       removeMembershipFromProject,
       (state, { payload: { membershipId, projectId } }) => {
-        delete state.projects[projectId].membershipIds[membershipId];
+        delete state.projects[projectId].memberships[membershipId];
       },
     );
 


### PR DESCRIPTION
## Description

Updates the `Project` datatype to contain Memberships. Uses the Membership List object from the backend, but does not keep any reference to the membership list; the mutations to update Membership info now pass through the project.

I realize now that I still haven't implemented the endpoints to add members to projects, remove them, etc. This mostly has not been implemented in the mobile client, so that can be implemented when the time comes.

Should be merged after [backend PR](https://github.com/techmatters/terraso-backend/pull/793)

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
