### PR TITLE
fix: Use case-insensitive match for user existence email query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.2",
-        "terraso-backend": "github:techmatters/terraso-backend#4929e5f",
+        "terraso-backend": "github:techmatters/terraso-backend#b619a7d",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -13101,7 +13101,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#4929e5f4599cebc2f107873dd0075885c4df5e46"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#b619a7dd784beb6ad21b8d4b1ea17b2b773bb26e"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.2",
-    "terraso-backend": "github:techmatters/terraso-backend#4929e5f",
+    "terraso-backend": "github:techmatters/terraso-backend#b619a7d",
     "uuid": "^9.0.1"
   },
   "scripts": {

--- a/src/account/accountService.ts
+++ b/src/account/accountService.ts
@@ -165,14 +165,14 @@ export const checkUserInProject = async (
 ) => {
   const existQuery = graphql(`
     query userExistsInProject($email: String!, $project: String!) {
-      userExists: users(email: $email) {
+      userExists: users(email_Iexact: $email) {
         edges {
           node {
             ...userFields
           }
         }
       }
-      userInProject: users(project: $project, email: $email) {
+      userInProject: users(project: $project, email_Iexact: $email) {
         totalCount
       }
     }


### PR DESCRIPTION
## Description

This will make it so the email match in the projects field does not care about if the user uses upper case or not.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
