### PR TITLE
feat: site transfer mutation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#3d323b5",
+        "terraso-backend": "github:techmatters/terraso-backend#f671497",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -13095,8 +13095,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#ed3430adbf10347f8ae687e5ebe4f8464f5b32eb",
-      "integrity": "sha512-awSy8YBN53+5FlZkEUPG0xPmoV6QMNVMzEVbKzD3hsoTD6XHwznxZqlfmRrIQVFFwaNKI7PxWkbmUfViOCxYrQ=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#f67149781a7fd91b896d30e40b355fbd4811091d"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#3d323b5",
+    "terraso-backend": "github:techmatters/terraso-backend#f671497",
     "uuid": "^9.0.1"
   },
   "scripts": {

--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -55,10 +55,10 @@ const generateProject = (
   };
 };
 
-const generateSite = (project: Project): Site => {
+const generateSite = (project?: Project): Site => {
   const id = uuidv4();
   const site: Site = {
-    projectId: project.id,
+    projectId: project?.id,
     ownerId: undefined,
     id,
     name: 'Test Site',
@@ -68,7 +68,9 @@ const generateSite = (project: Project): Site => {
     archived: false,
     updatedAt: '2023-10-24',
   };
-  project.sites[site.id] = true;
+  if (project !== undefined) {
+    project.sites[site.id] = true;
+  }
   return site;
 };
 
@@ -157,9 +159,10 @@ test('can access all projects with role', () => {
   const project3 = generateProject([generateMembership(user.id, 'manager')]);
   const site1 = generateSite(project1);
   const site2 = generateSite(project2);
+  const site3 = generateSite();
 
   const store = createStore(
-    initState([project1, project2, project3], [user], [site1, site2]),
+    initState([project1, project2, project3], [user], [site1, site2, site3]),
   );
   const pairs = selectProjectsWithTransferrableSites(
     store.getState(),
@@ -178,5 +181,6 @@ test('can access all projects with role', () => {
         siteName: site1.name,
       },
     ],
+    unaffiliatedSites: [{ siteId: site3.id, siteName: site3.name }],
   });
 });

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -52,13 +52,17 @@ export const selectProjectsWithTransferrableSites = createSelector(
           };
         }),
     );
-    let projectRecord = projects.reduce(
+
+    const unaffiliatedSites = Object.values(sites)
+      .filter(({ projectId }) => projectId === undefined)
+      .map(({ id, name }) => ({ siteId: id, siteName: name }));
+    const projectRecord = projects.reduce(
       (x, { id, name }) => ({
         ...x,
         [id]: { projectId: id, projectName: name },
       }),
       {} as Record<string, { projectId: string; projectName: string }>,
     );
-    return { projects: projectRecord, sites: projectSites };
+    return { projects: projectRecord, sites: projectSites, unaffiliatedSites };
   },
 );


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

I completely overlooked that unaffiliated sites, that is sites that are not a part of any project, must be included in the transfer site screen. This change just updates the relevant selector to include unaffiliated sites.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Related to https://github.com/techmatters/terraso-mobile-client/issues/145

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
