### PR TITLE
fix: Delete sites from project slice on update

### DIFF
--- a/src/site/siteSlice.ts
+++ b/src/site/siteSlice.ts
@@ -16,7 +16,10 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { SiteAddMutationInput } from 'terraso-client-shared/graphqlSchema/graphql';
+import {
+  SiteAddMutationInput,
+  SiteUpdateMutationInput,
+} from 'terraso-client-shared/graphqlSchema/graphql';
 import {
   addSiteToProject,
   removeSiteFromAllProjects,
@@ -68,9 +71,18 @@ export const addSite = createAsyncThunk<Site, SiteAddMutationInput>(
   },
 );
 
-export const updateSite = createAsyncThunk(
+export const updateSite = createAsyncThunk<Site, SiteUpdateMutationInput>(
   'site/updateSite',
-  siteService.updateSite,
+  async (input, _currentUser, { dispatch }) => {
+    const result = await siteService.updateSite(input);
+    dispatch(removeSiteFromAllProjects(result.id));
+    if (result.projectId) {
+      dispatch(
+        addSiteToProject({ projectId: result.projectId, siteId: input.id }),
+      );
+    }
+    return result;
+  },
 );
 
 export const deleteSite = createAsyncThunk<string, Site>(


### PR DESCRIPTION
## Description

Project update reducer needs to delete the site from the project slice on update, because this is the way that we're using to update the project slice sites for the moment.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

Needed for https://github.com/techmatters/terraso-mobile-client/issues/431