### PR TITLE
feat: Add new selectors site filter

### DIFF
--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   selectProjectMembershipsWithUsers,
   selectProjectsWithTransferrableSites,
+  selectSitesAndUserRoles,
 } from 'terraso-client-shared/selectors';
 import { Site } from 'terraso-client-shared/site/siteSlice';
 import { SerializableSet } from 'terraso-client-shared/store/utils';
@@ -182,5 +183,29 @@ test('can access all projects with role', () => {
       },
     ],
     unaffiliatedSites: [{ siteId: site3.id, siteName: site3.name }],
+  });
+});
+
+test('select user sites with project role', () => {
+  const user = generateUser();
+  const project1 = generateProject([generateMembership(user.id, 'manager')]);
+  const project2 = generateProject([
+    generateMembership(user.id, 'contributor'),
+  ]);
+  const site1 = generateSite(project1);
+  const site2 = generateSite(project2);
+  const site3 = generateSite();
+  const site4 = generateSite(project2);
+
+  const store = createStore(
+    initState([project1, project2], [user], [site1, site2, site3, site4]),
+  );
+
+  const roles = selectSitesAndUserRoles(store.getState(), user.id);
+  expect(roles).toStrictEqual({
+    [site1.id]: [site1, 'manager'],
+    [site2.id]: [site2, 'contributor'],
+    [site3.id]: [site3, undefined],
+    [site4.id]: [site4, 'contributor'],
   });
 });

--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -203,9 +203,9 @@ test('select user sites with project role', () => {
 
   const roles = selectSitesAndUserRoles(store.getState(), user.id);
   expect(roles).toStrictEqual({
-    [site1.id]: [site1, 'manager'],
-    [site2.id]: [site2, 'contributor'],
-    [site3.id]: [site3, undefined],
-    [site4.id]: [site4, 'contributor'],
+    [site1.id]: 'manager',
+    [site2.id]: 'contributor',
+    [site3.id]: undefined,
+    [site4.id]: 'contributor',
   });
 });

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -35,9 +35,12 @@ const selectProjectsWithUserRole = createSelector(
     ),
 );
 
-const selectProjectUserRoles = (state: SharedState, userId: string) => {
+const selectProjectUserRoles = (state: SharedState, userId?: string) => {
   return Object.fromEntries(
     mapValues(state.project.projects, project => {
+      if (userId === undefined) {
+        return {};
+      }
       const membership = Object.values(project.memberships).find(
         ({ userId: membUserId }) => membUserId === userId,
       );

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -35,6 +35,34 @@ const selectProjectsWithUserRole = createSelector(
     ),
 );
 
+const selectProjectUserRoles = (state: SharedState, userId: string) => {
+  return Object.fromEntries(
+    mapValues(state.project.projects, project => {
+      const membership = Object.values(project.memberships).find(
+        ({ userId: membUserId }) => membUserId === userId,
+      );
+      if (membership) {
+        return [project.id, membership.userRole];
+      }
+    }).filter((item): item is [string, UserRole] => item !== undefined),
+  );
+};
+
+export const selectSitesAndUserRoles = createSelector(
+  [selectProjectUserRoles, selectSites],
+  (userRoleMap, sites) => {
+    return Object.fromEntries(
+      mapValues(sites, site => {
+        let role = undefined;
+        if (site.projectId !== undefined) {
+          role = userRoleMap[site.projectId];
+        }
+        return [site.id, [site, role]];
+      }),
+    );
+  },
+);
+
 export const selectProjectsWithTransferrableSites = createSelector(
   [selectProjectsWithUserRole, selectSites],
   (projects, sites) => {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -57,7 +57,7 @@ export const selectSitesAndUserRoles = createSelector(
         if (site.projectId !== undefined) {
           role = userRoleMap[site.projectId];
         }
-        return [site.id, [site, role]];
+        return [site.id, role];
       }),
     );
   },


### PR DESCRIPTION
## Description
We need to associate sites to user roles. The user role is selected as the user's role in the project to which the site belongs (undefined if the site does not belong to a project).


### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Part of work for https://github.com/techmatters/terraso-mobile-client/issues/42

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
