### PR TITLE
feat: select project by role

### DIFF
--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -96,11 +96,22 @@ const keyBy = <T, Index extends keyof T>(
   );
 };
 
-function initState(projects: Project[], users: User[], sites: Site[] = []) {
+function initState(
+  projects: Project[],
+  users: User[],
+  sites: Site[] = [],
+  currentUserID?: string,
+) {
   return merge(
+    { account: { ...accountInitialState } },
     {
       account: {
         users: keyBy(users, 'id'),
+        currentUser: {
+          data: {
+            id: currentUserID ?? users[0]?.id,
+          },
+        },
       },
       project: {
         projects: keyBy(projects, 'id'),
@@ -109,7 +120,6 @@ function initState(projects: Project[], users: User[], sites: Site[] = []) {
         sites: keyBy(sites, 'id'),
       },
     },
-    { account: { ...accountInitialState } },
   );
 }
 
@@ -166,7 +176,12 @@ test('can access all projects with role', () => {
   const site3 = generateSite();
 
   const store = createStore(
-    initState([project1, project2, project3], [user], [site1, site2, site3]),
+    initState(
+      [project1, project2, project3],
+      [user],
+      [site1, site2, site3],
+      user.id,
+    ),
   );
   const pairs = selectProjectsWithTransferrableSites(
     store.getState(),
@@ -201,10 +216,15 @@ test('select user sites with project role', () => {
   const site4 = generateSite(project2);
 
   const store = createStore(
-    initState([project1, project2], [user], [site1, site2, site3, site4]),
+    initState(
+      [project1, project2],
+      [user],
+      [site1, site2, site3, site4],
+      user.id,
+    ),
   );
 
-  const roles = selectSitesAndUserRoles(store.getState(), user.id);
+  const roles = selectSitesAndUserRoles(store.getState());
   expect(roles).toStrictEqual({
     [site1.id]: 'manager',
     [site2.id]: 'contributor',

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -35,7 +35,7 @@ const selectProjectsWithUserRole = createSelector(
     ),
 );
 
-const selectProjectUserRoles = (state: SharedState, userId?: string) => {
+export const selectProjectUserRoles = (state: SharedState, userId?: string) => {
   return Object.fromEntries(
     mapValues(state.project.projects, project => {
       if (userId === undefined) {


### PR DESCRIPTION
## Description

- Needed to export one of the selectors that I was already using to map user role to project
- Realized in this process, re-reading the redux docs, that the selector was not defined properly, so had to refactor it a bit. The problem was that an intermediary selector was essentially creating a new object, which is not the way the intermediary selector are supposed to work. I separated out the function work and used it in the final selector.
- Changed the tests to adapt to the fact that the refactored selectors use the current user ID, instead of having to provide it explicitly.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Related to https://github.com/techmatters/terraso-mobile-client/issues/143

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
