### PR TITLE
feat: site soil async

### DIFF
--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -129,6 +129,12 @@ const soilIdSlice = createSlice({
     ) => {
       Object.assign(state.projectSettings, action.payload);
     },
+    setSoilDataStatus: (
+      state,
+      action: PayloadAction<'loading' | 'error' | 'ready'>,
+    ) => {
+      state.status = action.payload;
+    },
   },
   extraReducers: builder => {
     builder.addCase(updateSoilData.fulfilled, (state, action) => {


### PR DESCRIPTION
## Description

Adds reducers that update the soil ID state automatically when a user presses a switch on the soil tab. If the request fails, it rolls back the data and changes the store status to "error".

This implementation is very much a first attempt. The fact that the soil ID update updates the whole soil ID object, and the fact that soil IDs are a list rather than a hash set, make the reverse code a bit hacky. Hopefully in the future we can look into some libraries that will make this sort of operation easier.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
