### PR TITLE
feat: Selector for user role based on site

### DIFF
--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -244,9 +244,9 @@ test('select user sites with project role', () => {
 test('select user role when site owned', () => {
   const user = generateUser();
   const site = generateSite({ owner: user });
-  const store = createStore(initState([], [user], [site]));
+  const store = createStore(initState([], [user], [site], user.id));
 
-  const siteRole = selectUserRoleSite(store.getState(), site.id, user.id);
+  const siteRole = selectUserRoleSite(store.getState(), site.id);
   expect(siteRole).toStrictEqual({ kind: 'site', role: 'owner' });
 });
 
@@ -254,8 +254,8 @@ test('select user role in project of site', () => {
   const user = generateUser();
   const project = generateProject([generateMembership(user.id, 'viewer')]);
   const site = generateSite({ project });
-  const store = createStore(initState([project], [user], [site]));
+  const store = createStore(initState([project], [user], [site], user.id));
 
-  const siteRole = selectUserRoleSite(store.getState(), site.id, user.id);
+  const siteRole = selectUserRoleSite(store.getState(), site.id);
   expect(siteRole).toStrictEqual({ kind: 'project', role: 'viewer' });
 });

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -119,14 +119,11 @@ export type SiteUserRole =
   | { kind: 'site'; role: 'owner' }
   | { kind: 'project'; role: UserRole };
 
-const selectSiteId = (_state: any, siteId: string, userId: string) => [
-  siteId,
-  userId,
-];
+const selectSiteId = (_state: any, siteId: string) => siteId;
 
 export const selectUserRoleSite = createSelector(
-  [selectSites, selectProjects, selectSiteId],
-  (sites, projects, [siteId, userId]) => {
+  [selectSites, selectProjects, selectSiteId, selectCurrentUserID],
+  (sites, projects, siteId, userId) => {
     const site = sites[siteId];
     if (!site) {
       return null;


### PR DESCRIPTION
## Description

Adds a selector that will return a user's role to a site. It is unaffiliated, it will just return "owner" or null. Otherwise it will return the project role or null.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
