### PR TITLE
fix: Read project soil settings from projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#abd145f",
+        "terraso-backend": "github:techmatters/terraso-backend#889fb18e",
         "uuid": "^9.0.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#abd145f",
+    "terraso-backend": "github:techmatters/terraso-backend#889fb18e",
     "uuid": "^9.0.1"
   },
   "scripts": {

--- a/src/project/projectFragments.ts
+++ b/src/project/projectFragments.ts
@@ -59,5 +59,8 @@ export const projectData = /* GraphQL */ `
         }
       }
     }
+    soilSettings {
+      ...projectSoilSettings
+    }
   }
 `;

--- a/src/project/projectService.ts
+++ b/src/project/projectService.ts
@@ -91,6 +91,9 @@ export const collapseProjects = (
     ),
     sites: collapseMaps(...projects.map(({ sites }) => sites)),
     users: collapseMaps(...projects.map(({ users }) => users)),
+    soilSettings: collapseMaps(
+      ...projects.map(({ soilSettings }) => soilSettings),
+    ),
   };
 };
 

--- a/src/project/projectService.ts
+++ b/src/project/projectService.ts
@@ -77,7 +77,7 @@ export const collapseProject = ({
     },
     sites,
     users,
-    soilSettings: { [project.id]: soilSettings },
+    soilSettings: { [project.id]: { ...soilSettings } },
   };
 };
 

--- a/src/project/projectService.ts
+++ b/src/project/projectService.ts
@@ -61,6 +61,7 @@ const collapseProjectMemberships = (
 export const collapseProject = ({
   membershipList,
   siteSet,
+  soilSettings,
   ...project
 }: ProjectDataFragment) => {
   const sites = collapseSites(siteSet);
@@ -76,6 +77,7 @@ export const collapseProject = ({
     },
     sites,
     users,
+    soilSettings: { [project.id]: soilSettings },
   };
 };
 

--- a/src/project/projectSlice.ts
+++ b/src/project/projectSlice.ts
@@ -187,6 +187,7 @@ export const fetchProjectsForUser = createAsyncThunk(
     projects: setProjects,
     sites: setSites,
     users: setUsers,
+    soilSettings: updateProjectSettings,
   }),
 );
 

--- a/src/project/projectSlice.ts
+++ b/src/project/projectSlice.ts
@@ -28,6 +28,7 @@ import {
 } from 'terraso-client-shared/graphqlSchema/graphql';
 import * as projectService from 'terraso-client-shared/project/projectService';
 import { setSites, updateSites } from 'terraso-client-shared/site/siteSlice';
+import { setProjectSettings } from 'terraso-client-shared/soilId/soilIdSlice';
 import {
   createAsyncThunk,
   dispatchByKeys,
@@ -172,6 +173,7 @@ const updateDispatchMap = {
   project: (project: Project) => updateProjects({ [project.id]: project }),
   sites: updateSites,
   users: updateUsers,
+  soilSettings: setProjectSettings,
 };
 
 export const fetchProject = createAsyncThunk(

--- a/src/project/projectSlice.ts
+++ b/src/project/projectSlice.ts
@@ -28,7 +28,7 @@ import {
 } from 'terraso-client-shared/graphqlSchema/graphql';
 import * as projectService from 'terraso-client-shared/project/projectService';
 import { setSites, updateSites } from 'terraso-client-shared/site/siteSlice';
-import { setProjectSettings } from 'terraso-client-shared/soilId/soilIdSlice';
+import { updateProjectSoilSettings } from 'terraso-client-shared/soilId/soilIdSlice';
 import {
   createAsyncThunk,
   dispatchByKeys,
@@ -173,7 +173,7 @@ const updateDispatchMap = {
   project: (project: Project) => updateProjects({ [project.id]: project }),
   sites: updateSites,
   users: updateUsers,
-  soilSettings: setProjectSettings,
+  soilSettings: updateProjectSoilSettings,
 };
 
 export const fetchProject = createAsyncThunk(

--- a/src/project/projectSlice.ts
+++ b/src/project/projectSlice.ts
@@ -28,7 +28,7 @@ import {
 } from 'terraso-client-shared/graphqlSchema/graphql';
 import * as projectService from 'terraso-client-shared/project/projectService';
 import { setSites, updateSites } from 'terraso-client-shared/site/siteSlice';
-import { updateProjectSoilSettings } from 'terraso-client-shared/soilId/soilIdSlice';
+import { updateProjectSettings } from 'terraso-client-shared/soilId/soilIdSlice';
 import {
   createAsyncThunk,
   dispatchByKeys,
@@ -173,7 +173,7 @@ const updateDispatchMap = {
   project: (project: Project) => updateProjects({ [project.id]: project }),
   sites: updateSites,
   users: updateUsers,
-  soilSettings: updateProjectSoilSettings,
+  soilSettings: updateProjectSettings,
 };
 
 export const fetchProject = createAsyncThunk(

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -222,8 +222,12 @@ const soilIdSlice = createSlice({
   },
 });
 
-export const { setProjectSettings, setSoilData, setSoilIdStatus } =
-  soilIdSlice.actions;
+export const {
+  setProjectSettings,
+  setSoilData,
+  setSoilIdStatus,
+  updateProjectSettings,
+} = soilIdSlice.actions;
 
 export const fetchSoilDataForUser = createAsyncThunk(
   'soilId/fetchSoilDataForUser',


### PR DESCRIPTION
## Description

I made this to make sure that projects have soil settings - a bug was happening when a new project was created. However, I'm not really sure how this works with the already existing soilID fetch that already grabs settings - it seems like the work will be doubled a bit with this change.

BEFORE MERGING: Bump backend version when [backend PR](https://github.com/techmatters/terraso-backend/pull/1062) is merged

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
