### PR TITLE
feat: Generate project intervals on frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13397,8 +13397,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#eb859151210c69123178b88cfa4863b52d619bdc",
-      "integrity": "sha512-toJ1fC0pLlEIQpxKO9pAyJ3fC2cWov+nnQ7H0+lwmB6VddgM4FTx+mGKxGi/Vlgz6UyMx5jWenyEg2RmFFQufw=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#889fb18e543e81f51cfb3bf13fc19bfebec17c8e"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,23 @@
+type DepthIntervalBounds = {
+  start: number;
+  end: number;
+};
+
+export const PRESETS: Record<'LANDPKS' | 'NRCS', DepthIntervalBounds[]> = {
+  LANDPKS: [
+    { start: 0, end: 10 },
+    { start: 10, end: 20 },
+    { start: 20, end: 50 },
+    { start: 50, end: 70 },
+    { start: 70, end: 100 },
+    { start: 100, end: 200 },
+  ],
+  NRCS: [
+    { start: 0, end: 5 },
+    { start: 5, end: 15 },
+    { start: 15, end: 30 },
+    { start: 30, end: 60 },
+    { start: 60, end: 100 },
+    { start: 100, end: 200 },
+  ],
+};

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,10 +1,15 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { User } from 'terraso-client-shared/account/accountSlice';
+import { PRESETS } from 'terraso-client-shared/constants';
 import { UserRole } from 'terraso-client-shared/graphqlSchema/graphql';
 import {
   Project,
   ProjectMembership,
 } from 'terraso-client-shared/project/projectSlice';
+import {
+  ProjectDepthInterval,
+  ProjectSoilSettings,
+} from 'terraso-client-shared/soilId/soilIdSlice';
 import { type SharedState } from 'terraso-client-shared/store/store';
 import { exists, filterValues, mapValues } from 'terraso-client-shared/utils';
 
@@ -142,5 +147,38 @@ export const selectUserRoleSite = createSelector(
       return null;
     }
     return { kind: 'project', role: membership.userRole };
+  },
+);
+
+const generateProjectIntervals = (settings: ProjectSoilSettings) => {
+  let depthIntervals: ProjectDepthInterval[] | undefined;
+  switch (settings.depthIntervalPreset) {
+    case 'LANDPKS':
+    case 'NRCS':
+      depthIntervals = PRESETS[settings.depthIntervalPreset].map(
+        depthInterval => ({ depthInterval, label: '' }),
+      );
+      break;
+    case 'CUSTOM':
+      depthIntervals = settings.depthIntervals;
+      break;
+    case 'NONE':
+      depthIntervals = undefined;
+      break;
+  }
+  return depthIntervals;
+};
+
+export const selectProjectSettings = createSelector(
+  [
+    (state: SharedState, projectId: string) =>
+      state.soilId.projectSettings[projectId],
+  ],
+  (projectSettings: ProjectSoilSettings) => {
+    if (!projectSettings) {
+      return undefined;
+    }
+    const depthIntervals = generateProjectIntervals(projectSettings) || [];
+    return { ...projectSettings, depthIntervals };
   },
 );


### PR DESCRIPTION
## Description

If the user selects the LandPKS or NRCS presets, the project intervals are not stored in the backend but generated on the frontend. This PR introduces a selector that can be used to retrieve project settings from the redux store, and populate the correct project depth intervals according to the preset selected.