### PR TITLE
feat: Support generating soil depth intervals on the frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3298,13 +3298,13 @@
       }
     },
     "node_modules/@graphql-tools/prisma-loader": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.1.tgz",
-      "integrity": "sha512-bl6e5sAYe35Z6fEbgKXNrqRhXlCJYeWKBkarohgYA338/SD9eEhXtg3Cedj7fut3WyRLoQFpHzfiwxKs7XrgXg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.2.tgz",
+      "integrity": "sha512-8d28bIB0bZ9Bj0UOz9sHagVPW+6AHeqvGljjERtwCnWl8OCQw2c2pNboYXISLYUG5ub76r4lDciLLTU+Ks7Q0w==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/url-loader": "^8.0.0",
-        "@graphql-tools/utils": "^10.0.0",
+        "@graphql-tools/utils": "^10.0.8",
         "@types/js-yaml": "^4.0.0",
         "@types/json-stable-stringify": "^1.0.32",
         "@whatwg-node/fetch": "^0.9.0",
@@ -3314,7 +3314,7 @@
         "graphql-request": "^6.0.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
-        "jose": "^4.11.4",
+        "jose": "^5.0.0",
         "js-yaml": "^4.0.0",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.20",
@@ -10806,9 +10806,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.14.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
-      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13397,8 +13397,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#eb859151210c69123178b88cfa4863b52d619bdc",
-      "integrity": "sha512-toJ1fC0pLlEIQpxKO9pAyJ3fC2cWov+nnQ7H0+lwmB6VddgM4FTx+mGKxGi/Vlgz6UyMx5jWenyEg2RmFFQufw=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#889fb18e543e81f51cfb3bf13fc19bfebec17c8e"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4653,10 +4653,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.3.tgz",
-      "integrity": "sha512-Yu3+r4Mn/iY6Mf0aihncZQ1qOjOUrCiodbHHY1hds5O+7BbKp9t+Li7zLO13zO8j9L2C6euz8xsYQP0rjGvVXw==",
-      "dev": true
+      "version": "20.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.3.tgz",
+      "integrity": "sha512-nrlmbvGPNGaj84IJZXMPhQuCMEVTT/hXZMJJG/aIqVL9fKxqk814sGGtJA4GI6hpJSLQjpi6cn0Qx9eOf9SDVg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -13835,6 +13838,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#3ed93de7",
+        "terraso-backend": "github:techmatters/terraso-backend#efc75ec6",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -13380,7 +13380,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#3ed93de7a3c67685b962f18dbd89e4c6b6232e13"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#efc75ec6791dc47335f24e34c59e3c0df712d5bb"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,9 +1559,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.3.tgz",
-      "integrity": "sha512-vTG+cTGxPFou12Rj7ll+eD5yWeNl5/8xvQvF08y5Gv3v4mZQoyFf8/n9zg4q5vvCWt5jmgymfzMAldO7orBn7A==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
+      "integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#889fb18e",
+        "terraso-backend": "github:techmatters/terraso-backend#3ed93de7",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -3298,13 +3298,13 @@
       }
     },
     "node_modules/@graphql-tools/prisma-loader": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.2.tgz",
-      "integrity": "sha512-8d28bIB0bZ9Bj0UOz9sHagVPW+6AHeqvGljjERtwCnWl8OCQw2c2pNboYXISLYUG5ub76r4lDciLLTU+Ks7Q0w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.1.tgz",
+      "integrity": "sha512-bl6e5sAYe35Z6fEbgKXNrqRhXlCJYeWKBkarohgYA338/SD9eEhXtg3Cedj7fut3WyRLoQFpHzfiwxKs7XrgXg==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/url-loader": "^8.0.0",
-        "@graphql-tools/utils": "^10.0.8",
+        "@graphql-tools/utils": "^10.0.0",
         "@types/js-yaml": "^4.0.0",
         "@types/json-stable-stringify": "^1.0.32",
         "@whatwg-node/fetch": "^0.9.0",
@@ -3314,7 +3314,7 @@
         "graphql-request": "^6.0.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
-        "jose": "^5.0.0",
+        "jose": "^4.11.4",
         "js-yaml": "^4.0.0",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.20",
@@ -4653,13 +4653,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.3.tgz",
-      "integrity": "sha512-nrlmbvGPNGaj84IJZXMPhQuCMEVTT/hXZMJJG/aIqVL9fKxqk814sGGtJA4GI6hpJSLQjpi6cn0Qx9eOf9SDVg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
+      "version": "20.4.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.3.tgz",
+      "integrity": "sha512-Yu3+r4Mn/iY6Mf0aihncZQ1qOjOUrCiodbHHY1hds5O+7BbKp9t+Li7zLO13zO8j9L2C6euz8xsYQP0rjGvVXw==",
+      "dev": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -8457,20 +8454,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -10806,9 +10789,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
-      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
+      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -13397,7 +13380,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#889fb18e543e81f51cfb3bf13fc19bfebec17c8e"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#3ed93de7a3c67685b962f18dbd89e4c6b6232e13"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -13837,12 +13820,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#efc75ec6",
+        "terraso-backend": "github:techmatters/terraso-backend#1371c39d",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -13380,7 +13380,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#efc75ec6791dc47335f24e34c59e3c0df712d5bb"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#1371c39d38d5525fd1de5059718bd572ec51a4a0"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@babel/cli": "^7.23.0",
+        "@babel/cli": "^7.23.4",
         "@babel/core": "^7.23.3",
         "@babel/preset-env": "^7.23.3",
         "@babel/preset-react": "^7.23.3",
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.0.tgz",
-      "integrity": "sha512-17E1oSkGk2IwNILM4jtfAvgjt+ohmpfBky8aLerUfYZhiPNg7ca+CRCxZn8QDxwNhV/upsc2VHBCqGFIR+iBfA==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.4.tgz",
+      "integrity": "sha512-j3luA9xGKCXVyCa5R7lJvOMM+Kc2JEnAEIgz2ggtjQ/j5YUVgfsg/WsG95bbsgq7YLHuiCOzMnoSasuY16qiCw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "jest": "^29.7.0",
         "jest-axe": "^8.0.0",
         "jest-environment-jsdom": "^29.7.0",
-        "prettier": "^3.1.0",
+        "prettier": "^3.2.2",
         "ts-jest": "^29.1.1",
         "typescript": "^5.2.2",
         "whatwg-fetch": "^3.6.19"
@@ -12228,9 +12228,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
+      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier": "$prettier"
   },
   "devDependencies": {
-    "@babel/cli": "^7.23.0",
+    "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.3",
     "@babel/preset-env": "^7.23.3",
     "@babel/preset-react": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#889fb18e",
+    "terraso-backend": "github:techmatters/terraso-backend#3ed93de7",
     "uuid": "^9.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jest": "^29.7.0",
     "jest-axe": "^8.0.0",
     "jest-environment-jsdom": "^29.7.0",
-    "prettier": "^3.1.0",
+    "prettier": "^3.2.2",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2",
     "whatwg-fetch": "^3.6.19"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#3ed93de7",
+    "terraso-backend": "github:techmatters/terraso-backend#efc75ec6",
     "uuid": "^9.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#efc75ec6",
+    "terraso-backend": "github:techmatters/terraso-backend#1371c39d",
     "uuid": "^9.0.1"
   },
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,25 @@
-import { DepthInterval } from './graphqlSchema/graphql';
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import { DepthInterval } from 'terraso-client-shared/graphqlSchema/graphql';
 
-export const PRESETS: Record<'LANDPKS' | 'NRCS', DepthInterval[]> = {
+export const DEPTH_INTERVAL_PRESETS: Record<
+  'LANDPKS' | 'NRCS',
+  DepthInterval[]
+> = {
   LANDPKS: [
     { start: 0, end: 10 },
     { start: 10, end: 20 },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,6 @@
-type DepthIntervalBounds = {
-  start: number;
-  end: number;
-};
+import { DepthInterval } from './graphqlSchema/graphql';
 
-export const PRESETS: Record<'LANDPKS' | 'NRCS', DepthIntervalBounds[]> = {
+export const PRESETS: Record<'LANDPKS' | 'NRCS', DepthInterval[]> = {
   LANDPKS: [
     { start: 0, end: 10 },
     { start: 10, end: 20 },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,23 @@
+type DepthIntervalBounds = {
+  start: number;
+  end: number;
+};
+
+export const PRESETS: Record<'LANDPKS' | 'NRCS', DepthIntervalBounds[]> = {
+  LANDPKS: [
+    { start: 0, end: 10 },
+    { start: 10, end: 20 },
+    { start: 20, end: 50 },
+    { start: 50, end: 70 },
+    { start: 70, end: 100 },
+    { start: 100, end: 200 },
+  ],
+  NRCS: [
+    { start: 0, end: 5 },
+    { start: 5, end: 15 },
+    { start: 15, end: 30 },
+    { start: 30, end: 60 },
+    { start: 60, end: 100 },
+    { start: 100, end: 200 },
+  ],
+};

--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -3,7 +3,7 @@ import {
   initialState as accountInitialState,
   User,
 } from 'terraso-client-shared/account/accountSlice';
-import { PRESETS } from 'terraso-client-shared/constants';
+import { DEPTH_INTERVAL_PRESETS } from 'terraso-client-shared/constants';
 import {
   DepthInterval,
   ProjectPrivacy,
@@ -385,7 +385,7 @@ test('select predefined project selector', () => {
 
   expect(
     aggregatedIntervals.map(({ interval: { depthInterval } }) => depthInterval),
-  ).toStrictEqual(PRESETS['LANDPKS']);
+  ).toStrictEqual(DEPTH_INTERVAL_PRESETS['LANDPKS']);
 });
 
 test('select predefined project selector with custom preset', () => {

--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -441,7 +441,7 @@ test('select predefined project selector with custom preset', () => {
   ]);
 });
 
-test.only('overlapping site intervals get the project values of the preset interval', () => {
+test('overlapping site intervals get the project values of the preset interval', () => {
   const user = generateUser();
   const project = generateProject([generateMembership(user.id, 'manager')]);
   const site = generateSite({ project });

--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -441,13 +441,14 @@ test('select predefined project selector with custom preset', () => {
   ]);
 });
 
-test('overlapping site intervals get the project values of the preset interval', () => {
+test.only('overlapping site intervals get the project values of the preset interval', () => {
   const user = generateUser();
   const project = generateProject([generateMembership(user.id, 'manager')]);
   const site = generateSite({ project });
 
   const projectDepthIntervals = [
     { depthInterval: { start: 1, end: 2 }, label: 'first' },
+    { depthInterval: { start: 2, end: 3 }, label: 'second' },
   ];
   const projectSettings = createProjectSettings(project, {
     depthIntervalPreset: 'CUSTOM',
@@ -456,6 +457,9 @@ test('overlapping site intervals get the project values of the preset interval',
   const siteDepthIntervals = [
     generateSiteInterval({ start: 1, end: 2 }, 'label', {
       carbonatesEnabled: true,
+    }),
+    generateSiteInterval({ start: 2, end: 3 }, 'label', {
+      phEnabled: true,
     }),
   ];
   const soilData = createSoilData(site, {
@@ -479,5 +483,6 @@ test('overlapping site intervals get the project values of the preset interval',
       mutable: false,
       interval: { ...siteDepthIntervals[0], carbonatesEnabled: true },
     },
+    { mutable: false, interval: siteDepthIntervals[1] },
   ]);
 });

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,10 +1,15 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { User } from 'terraso-client-shared/account/accountSlice';
+import { PRESETS } from 'terraso-client-shared/constants';
 import { UserRole } from 'terraso-client-shared/graphqlSchema/graphql';
 import {
   Project,
   ProjectMembership,
 } from 'terraso-client-shared/project/projectSlice';
+import {
+  ProjectDepthInterval,
+  ProjectSoilSettings,
+} from 'terraso-client-shared/soilId/soilIdSlice';
 import { type SharedState } from 'terraso-client-shared/store/store';
 import { exists, filterValues, mapValues } from 'terraso-client-shared/utils';
 
@@ -142,5 +147,38 @@ export const selectUserRoleSite = createSelector(
       return null;
     }
     return { kind: 'project', role: membership.userRole };
+  },
+);
+
+const generateProjectIntervals = (settings: ProjectSoilSettings) => {
+  let depthIntervals: ProjectDepthInterval[] | undefined;
+  switch (settings.depthIntervalPreset) {
+    case 'LANDPKS':
+    case 'NRCS':
+      depthIntervals = PRESETS[settings.depthIntervalPreset].map(
+        depthInterval => ({ depthInterval, label: '' }),
+      );
+      break;
+    case 'CUSTOM':
+      depthIntervals = settings.depthIntervals;
+      break;
+    case 'NONE':
+      depthIntervals = undefined;
+      break;
+  }
+  return depthIntervals;
+};
+
+export const selectProjectSettings = createSelector(
+  [
+    (state: SharedState, projectId: string) =>
+      state.soilId.projectSettings[projectId],
+  ],
+  (projectSettings: ProjectSoilSettings) => {
+    if (!projectSettings) {
+      return undefined;
+    }
+    const depthIntervals = generateProjectIntervals(projectSettings) || [];
+    return { ...projectSettings, depthIntervals };
   },
 );

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { User } from 'terraso-client-shared/account/accountSlice';
-import { PRESETS } from 'terraso-client-shared/constants';
+import { DEPTH_INTERVAL_PRESETS } from 'terraso-client-shared/constants';
 import {
   DepthInterval,
   UserRole,
@@ -18,7 +18,6 @@ import {
   soilPitMethods,
 } from 'terraso-client-shared/soilId/soilIdSlice';
 import {
-  LabelOptional,
   ProjectDepthInterval,
   ProjectSoilSettings,
   SoilDataDepthInterval,
@@ -187,12 +186,12 @@ export const selectUserRoleProject = createSelector(
 );
 
 const generateProjectIntervals = (settings: ProjectSoilSettings) => {
-  let depthIntervals: LabelOptional<ProjectDepthInterval>[] | undefined;
+  let depthIntervals: ProjectDepthInterval[] | undefined;
   switch (settings.depthIntervalPreset) {
     case 'LANDPKS':
     case 'NRCS':
-      depthIntervals = PRESETS[settings.depthIntervalPreset].map(
-        depthInterval => ({ depthInterval }),
+      depthIntervals = DEPTH_INTERVAL_PRESETS[settings.depthIntervalPreset].map(
+        depthInterval => ({ depthInterval, label: '' }),
       );
       break;
     case 'CUSTOM':
@@ -209,7 +208,7 @@ const generateSiteIntervalPreset = (soilData: SoilData) => {
   switch (soilData.depthIntervalPreset) {
     case 'LANDPKS':
     case 'NRCS':
-      return PRESETS[soilData.depthIntervalPreset];
+      return DEPTH_INTERVAL_PRESETS[soilData.depthIntervalPreset];
     default:
       return [];
   }
@@ -237,9 +236,9 @@ const sortFn = (
 //  transform a project depth interval into a site soil interval + input methods
 //  i.e. a site soil interval
 export const makeSoilDepth = (
-  depthInterval: LabelOptional<ProjectDepthInterval>,
+  depthInterval: ProjectDepthInterval,
   soilSettings?: ProjectSoilSettings,
-): LabelOptional<SoilDataDepthInterval> => {
+): SoilDataDepthInterval => {
   const methodsEnabled = Object.fromEntries(
     soilPitMethods.map(method => [
       methodEnabled(method),
@@ -253,11 +252,11 @@ export type AggregatedInterval = {
   // can this interval be deleted + can its bounds be updated?
   mutable: boolean;
   // if label missing, label should not be assigned to this interval
-  interval: LabelOptional<SoilDataDepthInterval>;
+  interval: SoilDataDepthInterval;
 };
 
 const matchIntervals = (
-  presetIntervals: LabelOptional<ProjectDepthInterval>[],
+  presetIntervals: ProjectDepthInterval[],
   soilDepthIntervals: SoilDataDepthInterval[],
   soilSettings: ProjectSoilSettings | undefined,
 ) => {
@@ -342,6 +341,7 @@ export const selectSoilDataIntervals = createSelector(
       return matchIntervals(
         presetIntervals.map(depthInterval => ({
           depthInterval,
+          label: '',
         })),
         soilData.depthIntervals,
         undefined,

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -276,11 +276,6 @@ const matchIntervals = (
         intervals.push({ mutable: false, interval: B });
       } else if (A.depthInterval.start < B.depthInterval.start) {
         // no more site soil intervals that can overlap with preset
-        // add preset and continue to next
-        intervals.push({
-          mutable: false,
-          interval: makeSoilDepth(A, soilSettings),
-        });
         break;
       } else {
         // only add the "mutable" interval if it doesn't overlap with others
@@ -292,6 +287,10 @@ const matchIntervals = (
         }
       }
     }
+    intervals.push({
+      mutable: false,
+      interval: makeSoilDepth(A, soilSettings),
+    });
   }
   return intervals;
 };

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -11,6 +11,7 @@ import {
 } from 'terraso-client-shared/project/projectSlice';
 import {
   checkOverlap,
+  LabelOptional,
   methodEnabled,
   methodRequired,
   ProjectDepthInterval,
@@ -22,12 +23,7 @@ import {
   soilPitMethods,
 } from 'terraso-client-shared/soilId/soilIdSlice';
 import { type SharedState } from 'terraso-client-shared/store/store';
-import {
-  exists,
-  filterValues,
-  mapValues,
-  Optional,
-} from 'terraso-client-shared/utils';
+import { exists, filterValues, mapValues } from 'terraso-client-shared/utils';
 
 const selectProjectMemberships = (state: SharedState, projectId: string) =>
   state.project.projects[projectId]?.memberships ?? [];
@@ -247,8 +243,6 @@ export const makeSoilDepth = (
   ) as Record<`${SoilPitMethod}Enabled`, boolean>;
   return { ...depthInterval, ...methodsEnabled };
 };
-
-type LabelOptional<Type extends { label: string }> = Optional<Type, 'label'>;
 
 export type AggregatedInterval = {
   /* can this interval be deleted + can its bounds be updated? */

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -334,7 +334,13 @@ export const selectSoilDataIntervals = createSelector(
   (soilData: SoilData, projectSettings: ProjectSoilSettings | undefined) => {
     if (projectSettings === undefined) {
       // check site presets
-      const presetIntervals = generateSiteIntervalPreset(soilData);
+      const presetIntervals = generateSiteIntervalPreset({
+        ...soilData,
+        // default is LANDPKS if preset is not set
+        ...(!soilData.depthIntervalPreset
+          ? { depthIntervalPreset: 'LANDPKS' }
+          : {}),
+      });
       // match with overlapping site intervals
       return matchIntervals(
         presetIntervals.map(depthInterval => ({

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -272,7 +272,7 @@ const matchIntervals = (
 
   while (
     j < sortedSoilDepth.length &&
-    (sortedPresets.length == 0 ||
+    (sortedPresets.length === 0 ||
       sortedSoilDepth[j].depthInterval.end <=
         sortedPresets[0].depthInterval.start)
   ) {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -337,7 +337,7 @@ export const selectSoilDataIntervals = createSelector(
       const presetIntervals = generateSiteIntervalPreset({
         ...soilData,
         // default is LANDPKS if preset is not set
-        ...(!soilData.depthIntervalPreset
+        ...(soilData.depthIntervalPreset === undefined
           ? { depthIntervalPreset: 'LANDPKS' }
           : {}),
       });

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -267,7 +267,17 @@ const matchIntervals = (
 
   const intervals: AggregatedInterval[] = [];
 
-  for (let i = 0, j = 0; i < sortedPresets.length; i++) {
+  let j = 0;
+
+  while (
+    j < sortedSoilDepth.length &&
+    sortedSoilDepth[j].depthInterval.end <= sortedPresets[0].depthInterval.start
+  ) {
+    intervals.push({ mutable: true, interval: sortedSoilDepth[j] });
+    j++;
+  }
+
+  for (let i = 0; i < sortedPresets.length; i++) {
     const A = sortedPresets[i];
     for (; j < sortedSoilDepth.length; j++) {
       const B = sortedSoilDepth[j];
@@ -279,10 +289,7 @@ const matchIntervals = (
         break;
       } else {
         // only add the "mutable" interval if it doesn't overlap with others
-        if (
-          i >= sortedPresets.length ||
-          !checkOverlap(sortedPresets[i + 1])(B)
-        ) {
+        if (!checkOverlap(A)(B)) {
           intervals.push({ mutable: true, interval: B });
         }
       }
@@ -291,6 +298,11 @@ const matchIntervals = (
       mutable: false,
       interval: makeSoilDepth(A, soilSettings),
     });
+  }
+  while (j < sortedSoilDepth.length) {
+    // add any additional soil depth intervals
+    intervals.push({ mutable: true, interval: sortedSoilDepth[j] });
+    j++;
   }
   return intervals;
 };

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -208,7 +208,7 @@ const generateSiteIntervalPreset = (soilData: SoilData) => {
   switch (soilData.depthIntervalPreset) {
     case 'LANDPKS':
     case 'NRCS':
-      return PRESETS.LANDPKS;
+      return PRESETS[soilData.depthIntervalPreset];
     default:
       return [];
   }

--- a/src/soilId/soilIdFragments.ts
+++ b/src/soilId/soilIdFragments.ts
@@ -49,6 +49,7 @@ export const soilData = /* GraphQL */ `
     downSlope
     crossSlope
     bedrock
+    depthIntervalPreset
     slopeLandscapePosition
     slopeAspect
     slopeSteepnessSelect

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -107,7 +107,7 @@ export const sameDepth =
 export const checkOverlap =
   (a: { depthInterval: DepthInterval }) =>
   (b: { depthInterval: DepthInterval }) =>
-    Math.max(a.depthInterval.start, b.depthInterval.start) <=
+    Math.max(a.depthInterval.start, b.depthInterval.start) <
     Math.min(a.depthInterval.end, b.depthInterval.end);
 
 const soilIdSlice = createSlice({

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -155,9 +155,12 @@ const soilIdSlice = createSlice({
       state.soilData[action.meta.arg.siteId] = action.payload;
     });
 
-    builder.addCase(updateSoilDataDepthInterval.fulfilled, (state, action) => {
-      state.soilData[action.meta.arg.siteId] = action.payload;
-    });
+    builder.addCase(
+      updateSoilDataDepthIntervalAsync.fulfilled,
+      (state, action) => {
+        state.soilData[action.meta.arg.siteId] = action.payload;
+      },
+    );
 
     builder.addCase(
       updateSoilDataDepthIntervalAsync.pending,

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -104,6 +104,12 @@ export const sameDepth =
     a.depthInterval.start === b.depthInterval.start &&
     a.depthInterval.end === b.depthInterval.end;
 
+export const checkOverlap =
+  (a: { depthInterval: DepthInterval }) =>
+  (b: { depthInterval: DepthInterval }) =>
+    Math.max(a.depthInterval.start, b.depthInterval.start) <=
+    Math.min(a.depthInterval.end, b.depthInterval.end);
+
 const soilIdSlice = createSlice({
   name: 'soilId',
   initialState,

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -158,9 +158,6 @@ const soilIdSlice = createSlice({
             ([key, result]) => result !== null && key !== 'siteId',
           ),
         );
-        if (action.meta.arg.newDepthInterval) {
-          update.depthInterval = action.meta.arg.newDepthInterval;
-        }
         const index = currentState.depthIntervals.findIndex(
           a => a.depthInterval.start === action.meta.arg.depthInterval.start,
         );

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -32,6 +32,7 @@ import {
   createAsyncThunk,
   dispatchByKeys,
 } from 'terraso-client-shared/store/utils';
+import { Optional } from 'terraso-client-shared/utils';
 
 export const soilPitMethods = [
   'soilTexture',
@@ -78,12 +79,17 @@ export type SoilData = Omit<
   depthIntervals: SoilDataDepthInterval[];
   depthDependentData: DepthDependentSoilData[];
 };
+
+export type LabelOptional<Type extends { label: string }> = Optional<
+  Type,
+  'label'
+>;
 export type ProjectDepthInterval = Omit<ProjectDepthIntervalNode, 'project'>;
 export type ProjectSoilSettings = Omit<
   ProjectSoilSettingsNode,
   'project' | 'depthIntervals'
 > & {
-  depthIntervals: ProjectDepthInterval[];
+  depthIntervals: LabelOptional<ProjectDepthInterval>[];
 };
 
 export type SoilState = {

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -158,9 +158,13 @@ const soilIdSlice = createSlice({
             ([key, result]) => result !== null && key !== 'siteId',
           ),
         );
+        if (action.meta.arg.newDepthInterval) {
+          update.depthInterval = action.meta.arg.newDepthInterval;
+        }
         const index = currentState.depthIntervals.findIndex(
           a => a.depthInterval.start === action.meta.arg.depthInterval.start,
         );
+
         const interval =
           state.soilData[action.meta.arg.siteId].depthIntervals[index];
         state.soilData[action.meta.arg.siteId].depthIntervals[index] = {

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -152,7 +152,6 @@ const soilIdSlice = createSlice({
     });
 
     builder.addCase(updateSoilDataDepthInterval.fulfilled, (state, action) => {
-      console.debug(action.payload);
       state.soilData[action.meta.arg.siteId] = action.payload;
     });
 

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -86,7 +86,7 @@ export type ProjectSoilSettings = Omit<
   depthIntervals: ProjectDepthInterval[];
 };
 
-type SoilState = {
+export type SoilState = {
   soilData: Record<string, SoilData>;
   projectSettings: Record<string, ProjectSoilSettings>;
   status: 'loading' | 'error' | 'ready';

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -152,6 +152,7 @@ const soilIdSlice = createSlice({
     });
 
     builder.addCase(updateSoilDataDepthInterval.fulfilled, (state, action) => {
+      console.debug(action.payload);
       state.soilData[action.meta.arg.siteId] = action.payload;
     });
 

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -155,6 +155,10 @@ const soilIdSlice = createSlice({
       state.soilData[action.meta.arg.siteId] = action.payload;
     });
 
+    builder.addCase(updateSoilDataDepthInterval.fulfilled, (state, action) => {
+      state.soilData[action.meta.arg.siteId] = action.payload;
+    });
+
     builder.addCase(
       updateSoilDataDepthIntervalAsync.pending,
       (state, action) => {

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -25,7 +25,6 @@ import type {
   SoilIdDepthDependentSoilDataRockFragmentVolumeChoices,
   SoilIdDepthDependentSoilDataTextureChoices,
 } from 'terraso-client-shared/graphqlSchema/graphql';
-import { Optional } from 'terraso-client-shared/utils';
 
 export const soilPitMethods = [
   'soilTexture',
@@ -90,8 +89,3 @@ export const textures = [
 
 export type RockFragmentVolume =
   SoilIdDepthDependentSoilDataRockFragmentVolumeChoices;
-
-export type LabelOptional<Type extends { label: string }> = Optional<
-  Type,
-  'label'
->;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,3 +20,5 @@ export const normalizeText = (text: string) =>
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, ''); // unicode range for combining diacritical marks
+
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;


### PR DESCRIPTION
## Description

The central part of this PR provides a selector that generates the correct soil pit intervals for a given site. It determines based on the redux store which soil pit intervals need to generated, and whether any of these soil pit intervals should be matched to existing soil pit interval data saved in the database. It also wraps this information in a type `AggregatedInterval`, which can be used to determine if the underlying interval also supports updating its bounds -- intervals generated by a project preset do not support this.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
