### PR TITLE
fix: Handle case where depth interval preset is null

### DIFF
--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -367,10 +367,11 @@ export const selectSoilDataIntervals = createSelector(
   (soilData: SoilData, projectSettings: ProjectSoilSettings | undefined) => {
     if (projectSettings === undefined) {
       // check site presets
+
       const presetIntervals = generateSiteIntervalPreset({
         ...soilData,
         // default is LANDPKS if preset is not set
-        ...(soilData.depthIntervalPreset === undefined
+        ...(!soilData.depthIntervalPreset
           ? { depthIntervalPreset: 'LANDPKS' }
           : {}),
       });


### PR DESCRIPTION
## Description

Site soil data preset default is null, not undefined - this changes it so we just check the bool value of the field
