### PR TITLE
fix: Restrict site transfer sites to projects where user is manager

### DIFF
--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -123,11 +123,14 @@ export const selectSitesAndUserRoles = createSelector(
 );
 
 export const selectProjectsWithTransferrableSites = createSelector(
-  [selectProjectsWithUserRole, selectSites],
-  (projects, sites) => {
+  [selectProjectsWithUserRole, selectSites, selectSitesAndUserRoles],
+  (projects, sites, sitesWithRoles) => {
     const projectSites = projects.flatMap(project =>
       Object.keys(project.sites)
-        .filter(siteId => siteId in project.sites)
+        .filter(
+          siteId =>
+            siteId in project.sites && sitesWithRoles[siteId] === 'manager',
+        )
         .map(siteId => {
           const joinedSite = sites[siteId];
 


### PR DESCRIPTION
## Description

Restricts transferred sites in projects to where user is manager.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes https://github.com/techmatters/terraso-mobile-client/issues/565 (but mobile client will need to be updated to use this version!)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
