### PR TITLE
fix: hue ordering

### DIFF
--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -124,9 +124,9 @@ export const colorHues = [
   'BG',
   'G',
   'GY',
-  'R',
   'Y',
   'YR',
+  'R',
 ] as const satisfies readonly SoilColorHue[];
 
 export type SoilColorHueSubstep =


### PR DESCRIPTION
## Description
Just makes the ordering of the hues in the enum match that of the actual munsell color system. Needed for https://github.com/techmatters/terraso-mobile-client/pull/882