### PR TITLE
fix: rename MembershipsInfo to MembershipInfo, membershipsSample to memberships

### DIFF
--- a/src/collaboration/membershipsFragments.ts
+++ b/src/collaboration/membershipsFragments.ts
@@ -35,8 +35,8 @@ export const collaborationMembershipsPending = /* GraphQL */ `
   }
 `;
 
-export const collaborationMembershipsInfo = /* GraphQL */ `
-  fragment collaborationMembershipsInfo on CollaborationMembershipListNode {
+export const collaborationMembershipInfo = /* GraphQL */ `
+  fragment collaborationMembershipInfo on CollaborationMembershipListNode {
     membershipType
     membershipsCount
     enrollMethod

--- a/src/collaboration/membershipsUtils.ts
+++ b/src/collaboration/membershipsUtils.ts
@@ -31,7 +31,7 @@ type MembershipQuery = Partial<
     CollaborationMembershipsPendingFragment
 >;
 
-export type MembershipsInfo = {
+export type MembershipInfo = {
   totalCount?: number;
   pendingCount?: number;
   accountMembership?: Membership;
@@ -42,7 +42,7 @@ export type MembershipsInfo = {
 
 export type MembershipList = {
   // TODO: massage membershipsUtils/Service so more of these can be required
-  membershipsInfo?: MembershipsInfo;
+  membershipInfo?: MembershipInfo;
   id: string;
   slug: string;
   membershipType: 'CLOSED' | 'OPEN';
@@ -56,9 +56,9 @@ export type Membership = {
   user?: User;
 };
 
-export const extractMembershipsInfo = (
+export const extractMembershipInfo = (
   membershipList?: MembershipQuery | null,
-): MembershipsInfo => ({
+): MembershipInfo => ({
   totalCount:
     membershipList?.membershipsCount ?? membershipList?.memberships?.totalCount,
   pendingCount: membershipList?.pending?.totalCount,

--- a/src/collaboration/membershipsUtils.ts
+++ b/src/collaboration/membershipsUtils.ts
@@ -20,13 +20,13 @@ import { User } from 'terraso-client-shared/account/accountSlice';
 import type {
   AccountCollaborationMembershipFragment,
   CollaborationMembershipFieldsFragment,
+  CollaborationMembershipInfoFragment,
   CollaborationMembershipsFragment,
-  CollaborationMembershipsInfoFragment,
   CollaborationMembershipsPendingFragment,
 } from 'terraso-client-shared/graphqlSchema/graphql';
 
 type MembershipQuery = Partial<
-  CollaborationMembershipsInfoFragment &
+  CollaborationMembershipInfoFragment &
     AccountCollaborationMembershipFragment &
     CollaborationMembershipsPendingFragment
 >;

--- a/src/collaboration/membershipsUtils.ts
+++ b/src/collaboration/membershipsUtils.ts
@@ -35,7 +35,7 @@ export type MembershipsInfo = {
   totalCount?: number;
   pendingCount?: number;
   accountMembership?: Membership;
-  membershipsSample?: Membership[];
+  memberships?: Membership[];
   enrollMethod?: string;
   membershipType?: string;
 };
@@ -63,7 +63,7 @@ export const extractMembershipsInfo = (
     membershipList?.membershipsCount ?? membershipList?.memberships?.totalCount,
   pendingCount: membershipList?.pending?.totalCount,
   accountMembership: extractAccountMembership(membershipList),
-  membershipsSample: extractMemberships(membershipList),
+  memberships: extractMemberships(membershipList),
   enrollMethod: membershipList?.enrollMethod,
   membershipType: membershipList?.membershipType,
 });


### PR DESCRIPTION
## Description
Rename MembershipsInfo to MembershipInfo, membershipsSample to memberships.

### Related Issues
Fixes #216.
Supports https://github.com/techmatters/terraso-web-client/pull/1726