### PR TITLE
fix: downgrade react for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "jest-axe": "^8.0.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.2.5",
+        "react-dom": "18.2.0",
         "ts-jest": "^29.1.2",
         "typescript": "^5.4.5",
         "whatwg-fetch": "^3.6.20"
@@ -12506,17 +12507,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -13015,7 +13015,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
-        "react": "^18.3.1",
+        "react": "18.2.0",
         "react-redux": "^8.1.3",
         "terraso-backend": "github:techmatters/terraso-backend#fe4cbf8",
         "uuid": "^9.0.1"
@@ -12495,9 +12495,9 @@
       ]
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jest-axe": "^8.0.0",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.2.5",
+    "react-dom": "18.2.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.5",
     "whatwg-fetch": "^3.6.20"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@reduxjs/toolkit": "^1.9.7",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
-    "react": "^18.3.1",
+    "react": "18.2.0",
     "react-redux": "^8.1.3",
     "terraso-backend": "github:techmatters/terraso-backend#fe4cbf8",
     "uuid": "^9.0.1"


### PR DESCRIPTION
## Description
Downgrades react to a version compatible with the mobile client, which is stuck on version 18.2.0 because that's what react native has pinned.

