### PR TITLE
feat: Enable calling the Soil ID API with input from frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^1.9.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
+        "munsell": "^1.1.5",
         "react": "18.2.0",
         "react-redux": "^8.1.3",
         "terraso-backend": "github:techmatters/terraso-backend#fe4cbf8",
@@ -11682,6 +11683,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/munsell": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/munsell/-/munsell-1.1.5.tgz",
+      "integrity": "sha512-awJvYUNYoYvvr/osA1U0GZtJcDMV83aW5n7H6pu0Ag6Lo7ctqRQt7RNKrTr7j9GSfTUBfYlgInKgsUNaDqIfaA=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@reduxjs/toolkit": "^1.9.7",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
+    "munsell": "^1.1.5",
     "react": "18.2.0",
     "react-redux": "^8.1.3",
     "terraso-backend": "github:techmatters/terraso-backend#fe4cbf8",

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -30,7 +30,7 @@ import {
   DepthInterval,
   SoilData,
   SoilPitMethod,
-} from './soilIdTypes';
+} from 'terraso-client-shared/soilId/soilIdTypes';
 
 export const methodEnabled = <T extends SoilPitMethod>(
   method: T,

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -23,7 +23,6 @@ import {
   SoilIdInputDepthDependentData,
   SoilIdSoilDataSlopeSteepnessSelectChoices,
 } from 'terraso-client-shared/graphqlSchema/graphql';
-
 import {
   CollectionMethod,
   DepthDependentSoilData,

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -15,7 +15,22 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { CollectionMethod, DepthInterval, SoilPitMethod } from './soilIdTypes';
+import { mhvcToLab } from 'munsell';
+import {
+  LabColorInput,
+  Maybe,
+  SoilIdInputData,
+  SoilIdInputDepthDependentData,
+  SoilIdSoilDataSlopeSteepnessSelectChoices,
+} from 'terraso-client-shared/graphqlSchema/graphql';
+
+import {
+  CollectionMethod,
+  DepthDependentSoilData,
+  DepthInterval,
+  SoilData,
+  SoilPitMethod,
+} from './soilIdTypes';
 
 export const methodEnabled = <T extends SoilPitMethod>(
   method: T,
@@ -39,3 +54,86 @@ export const compareInterval = (
   { depthInterval: a }: { depthInterval: DepthInterval },
   { depthInterval: b }: { depthInterval: DepthInterval },
 ) => a.start - b.start;
+
+export const degreeToPercent = (degrees: number) =>
+  Math.round(Math.tan((degrees * Math.PI) / 180) * 100);
+
+export const selectToPercent = (
+  select: SoilIdSoilDataSlopeSteepnessSelectChoices,
+) => {
+  switch (select) {
+    /** 0 - 2% (flat) */
+    case 'FLAT':
+      return 0.0;
+    /** 2 - 5% (gentle) */
+    case 'GENTLE':
+      return 0.02;
+    /** 15 - 30% (hilly) */
+    case 'HILLY':
+      return 0.15;
+    /** 5 - 10% (moderate) */
+    case 'MODERATE':
+      return 0.05;
+    /** 50 - 60% (moderately steep) */
+    case 'MODERATELY_STEEP':
+      return 0.5;
+    /** 10 - 15% (rolling) */
+    case 'ROLLING':
+      return 0.1;
+    /** 30 - 50% (steep) */
+    case 'STEEP':
+      return 0.3;
+    /** 100%+ (steepest) */
+    case 'STEEPEST':
+      return 1.0;
+    /** 60 - 100% (very steep) */
+    case 'VERY_STEEP':
+      return 0.6;
+  }
+};
+
+export const soilDataSlopePercent = (
+  data: SoilData,
+): Maybe<number> | undefined => {
+  if (data.slopeSteepnessSelect) {
+    return selectToPercent(data.slopeSteepnessSelect!);
+  } else if (typeof data.slopeSteepnessDegree === 'number') {
+    return degreeToPercent(data.slopeSteepnessDegree);
+  } else {
+    return data.slopeSteepnessPercent;
+  }
+};
+
+export const soilDataLabColorInput = (
+  data: DepthDependentSoilData,
+): LabColorInput | undefined => {
+  if (
+    typeof data.colorHue !== 'number' ||
+    typeof data.colorValue !== 'number' ||
+    typeof data.colorChroma !== 'number'
+  ) {
+    return undefined;
+  }
+  const [L, A, B] = mhvcToLab(data.colorHue, data.colorValue, data.colorChroma);
+  return { L, A, B };
+};
+
+export const soilDataToIdInput = (data: SoilData): SoilIdInputData => {
+  return {
+    depthDependentData: data.depthDependentData.map(
+      soilDepthDependentDataToIdInput,
+    ),
+    slope: soilDataSlopePercent(data),
+  };
+};
+
+export const soilDepthDependentDataToIdInput = (
+  data: DepthDependentSoilData,
+): SoilIdInputDepthDependentData => {
+  return {
+    depthInterval: data.depthInterval,
+    colorLAB: soilDataLabColorInput(data),
+    rockFragmentVolume: data.rockFragmentVolume,
+    texture: data.texture,
+  };
+};

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import { CollectionMethod, DepthInterval, SoilPitMethod } from './soilIdTypes';
+
+export const methodEnabled = <T extends SoilPitMethod>(
+  method: T,
+): `${T}Enabled` => `${method}Enabled`;
+
+export const methodRequired = <T extends CollectionMethod>(
+  method: T,
+): `${T}Required` => `${method}Required`;
+
+export const sameDepth =
+  ({ depthInterval: a }: { depthInterval: DepthInterval }) =>
+  ({ depthInterval: b }: { depthInterval: DepthInterval }) =>
+    a.start === b.start && a.end === b.end;
+
+export const overlaps =
+  ({ depthInterval: a }: { depthInterval: DepthInterval }) =>
+  ({ depthInterval: b }: { depthInterval: DepthInterval }) =>
+    Math.max(a.start, b.start) < Math.min(a.end, b.end);
+
+export const compareInterval = (
+  { depthInterval: a }: { depthInterval: DepthInterval },
+  { depthInterval: b }: { depthInterval: DepthInterval },
+) => a.start - b.start;

--- a/src/soilId/soilIdSelectors.ts
+++ b/src/soilId/soilIdSelectors.ts
@@ -1,0 +1,10 @@
+import { SharedState } from 'terraso-client-shared/store/store';
+
+export const selectSoilIdData = () => (state: SharedState) =>
+  state.soilId.soilIdData;
+
+export const selectSoilIdInput = () => (state: SharedState) =>
+  state.soilId.soilIdParams;
+
+export const selectSoilIdStatus = () => (state: SharedState) =>
+  state.soilId.soilIdStatus;

--- a/src/soilId/soilIdSelectors.ts
+++ b/src/soilId/soilIdSelectors.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
 import { SharedState } from 'terraso-client-shared/store/store';
 
 export const selectSoilIdData = () => (state: SharedState) =>

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -24,33 +24,33 @@ import { Coords } from 'terraso-client-shared/types';
 
 export const fetchSoilMatches = async ({
   coords,
+  siteId,
   soilData,
 }: {
-  coords?: Coords;
+  coords: Coords;
   siteId?: string;
   soilData?: SoilData;
 }) => {
   /*
-   * One or both of the match types (location, data-based) will need to be queried.
-   * Fetch them both and return a promise that will complete when both are done.
-   * If a query isn't applicable, just return an empty match array.
+   * Depending on the given input parameters, one of the two APIs needs to be queried.
    */
-  const locationFetch = coords
-    ? fetchLocationBasedSoilMatches(coords)
-    : Promise.resolve({ matches: [] });
-  const dataFetch =
-    coords && soilData
-      ? fetchDataBasedSoilMatches(coords, soilDataToIdInput(soilData))
-      : Promise.resolve({ matches: [] });
-
-  return Promise.all([locationFetch, dataFetch]).then(
-    ([locationBasedMatches, dataBasedMatches]) => {
+  if (siteId && soilData) {
+    return fetchDataBasedSoilMatches(coords, soilDataToIdInput(soilData)).then(
+      result => {
+        return {
+          locationBasedMatches: [],
+          dataBasedMatches: result.matches,
+        };
+      },
+    );
+  } else {
+    return fetchLocationBasedSoilMatches(coords).then(result => {
       return {
-        locationBasedMatches: locationBasedMatches.matches,
-        dataBasedMatches: dataBasedMatches.matches,
+        locationBasedMatches: result.matches,
+        dataBasedMatches: [],
       };
-    },
-  );
+    });
+  }
 };
 
 export const fetchLocationBasedSoilMatches = async (coords: Coords) => {

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -33,6 +33,8 @@ export const fetchSoilMatches = async ({
 }) => {
   /*
    * Depending on the given input parameters, one of the two APIs needs to be queried.
+   * Sites with data use the "data based" soil matches API, as it can use soil data and location
+   * Temporary locations use the "location based" soil matches API, only using location
    */
   if (siteId && soilData) {
     return fetchDataBasedSoilMatches(coords, soilDataToIdInput(soilData)).then(

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -17,17 +17,17 @@
 
 import { graphql } from 'terraso-client-shared/graphqlSchema';
 import { SoilIdInputData } from 'terraso-client-shared/graphqlSchema/graphql';
+import { soilDataToIdInput } from 'terraso-client-shared/soilId/soilIdFunctions';
+import { SoilData } from 'terraso-client-shared/soilId/soilIdTypes';
 import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import { Coords } from 'terraso-client-shared/types';
-
-import { soilDataToIdInput } from './soilIdFunctions';
-import { SoilData } from './soilIdTypes';
 
 export const fetchSoilMatches = async ({
   coords,
   soilData,
 }: {
   coords?: Coords;
+  siteId?: string;
   soilData?: SoilData;
 }) => {
   /*

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -23,10 +23,13 @@ import { Coords } from 'terraso-client-shared/types';
 import { soilDataToIdInput } from './soilIdFunctions';
 import { SoilData } from './soilIdTypes';
 
-export const fetchSoilMatches = async (
-  coords?: Coords,
-  soilData?: SoilData,
-) => {
+export const fetchSoilMatches = async ({
+  coords,
+  soilData,
+}: {
+  coords?: Coords;
+  soilData?: SoilData;
+}) => {
   /*
    * One or both of the match types (location, data-based) will need to be queried.
    * Fetch them both and return a promise that will complete when both are done.
@@ -43,8 +46,8 @@ export const fetchSoilMatches = async (
   return Promise.all([locationFetch, dataFetch]).then(
     ([locationBasedMatches, dataBasedMatches]) => {
       return {
-        locationBasedMatches: locationBasedMatches,
-        dataBasedMatches: dataBasedMatches,
+        locationBasedMatches: locationBasedMatches.matches,
+        dataBasedMatches: dataBasedMatches.matches,
       };
     },
   );

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -32,9 +32,9 @@ export const fetchSoilMatches = async ({
   soilData?: SoilData;
 }) => {
   /*
-   * Depending on the given input parameters, one of the two APIs needs to be queried.
-   * Sites with data use the "data based" soil matches API, as it can use soil data and location
-   * Temporary locations use the "location based" soil matches API, only using location
+   * We call different APIs for different input scenarios.
+   * When soil data is available, we use the data-based soil match API.
+   * When the input is only a location, we use the location-based soil match API.
    */
   if (siteId && soilData) {
     return fetchDataBasedSoilMatches(coords, soilDataToIdInput(soilData)).then(

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -32,10 +32,12 @@ import {
 export * from 'terraso-client-shared/soilId/soilIdTypes';
 export * from 'terraso-client-shared/soilId/soilIdFunctions';
 
+export type LoadingState = 'loading' | 'error' | 'ready';
+
 export type SoilState = {
   soilData: Record<string, SoilData | undefined>;
   projectSettings: Record<string, ProjectSoilSettings | undefined>;
-  status: 'loading' | 'error' | 'ready';
+  status: LoadingState;
 };
 
 const initialState: SoilState = {

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -121,7 +121,7 @@ const soilIdSlice = createSlice({
 
     builder.addCase(deleteSoilDataDepthInterval.fulfilled, (state, action) => {
       state.soilData[action.meta.arg.siteId] = action.payload;
-      
+
       state.soilIdData.dataBasedMatches = [];
       state.soilIdParams.siteId = undefined;
     });

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -22,6 +22,7 @@ import { setSites } from 'terraso-client-shared/site/siteSlice';
 import * as soilDataService from 'terraso-client-shared/soilId/soilDataService';
 import * as soilIdService from 'terraso-client-shared/soilId/soilIdService';
 import {
+  LoadingState,
   ProjectSoilSettings,
   SoilData,
   SoilIdParams,
@@ -35,8 +36,6 @@ import {
 export * from 'terraso-client-shared/soilId/soilIdTypes';
 export * from 'terraso-client-shared/soilId/soilIdFunctions';
 
-export type LoadingState = 'loading' | 'error' | 'ready';
-
 export type SoilState = {
   soilData: Record<string, SoilData | undefined>;
   projectSettings: Record<string, ProjectSoilSettings | undefined>;
@@ -44,7 +43,7 @@ export type SoilState = {
 
   soilIdParams: SoilIdParams;
   soilIdData: SoilIdResults;
-  soilIdStatus: 'loading' | 'error' | 'ready';
+  soilIdStatus: LoadingState;
 };
 
 const initialState: SoilState = {

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -21,11 +21,8 @@ import { setProjects } from 'terraso-client-shared/project/projectSlice';
 import { setSites } from 'terraso-client-shared/site/siteSlice';
 import * as soilDataService from 'terraso-client-shared/soilId/soilDataService';
 import {
-  CollectionMethod,
-  DepthInterval,
   ProjectSoilSettings,
   SoilData,
-  SoilPitMethod,
 } from 'terraso-client-shared/soilId/soilIdTypes';
 import {
   createAsyncThunk,
@@ -33,14 +30,7 @@ import {
 } from 'terraso-client-shared/store/utils';
 
 export * from 'terraso-client-shared/soilId/soilIdTypes';
-
-export const methodEnabled = <T extends SoilPitMethod>(
-  method: T,
-): `${T}Enabled` => `${method}Enabled`;
-
-export const methodRequired = <T extends CollectionMethod>(
-  method: T,
-): `${T}Required` => `${method}Required`;
+export * from 'terraso-client-shared/soilId/soilIdFunctions';
 
 export type SoilState = {
   soilData: Record<string, SoilData | undefined>;
@@ -53,21 +43,6 @@ const initialState: SoilState = {
   projectSettings: {},
   status: 'loading',
 };
-
-export const sameDepth =
-  ({ depthInterval: a }: { depthInterval: DepthInterval }) =>
-  ({ depthInterval: b }: { depthInterval: DepthInterval }) =>
-    a.start === b.start && a.end === b.end;
-
-export const overlaps =
-  ({ depthInterval: a }: { depthInterval: DepthInterval }) =>
-  ({ depthInterval: b }: { depthInterval: DepthInterval }) =>
-    Math.max(a.start, b.start) < Math.min(a.end, b.end);
-
-export const compareInterval = (
-  { depthInterval: a }: { depthInterval: DepthInterval },
-  { depthInterval: b }: { depthInterval: DepthInterval },
-) => a.start - b.start;
 
 const soilIdSlice = createSlice({
   name: 'soilId',

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -16,8 +16,10 @@
  */
 
 import type {
+  DataBasedSoilMatch,
   DepthDependentSoilDataNode,
   DepthInterval,
+  LocationBasedSoilMatch,
   ProjectDepthIntervalNode,
   ProjectSoilSettingsNode,
   SoilDataDepthIntervalNode,
@@ -27,6 +29,7 @@ import type {
   SoilIdProjectSoilSettingsDepthIntervalPresetChoices,
   SoilIdSoilDataSurfaceCracksSelectChoices,
 } from 'terraso-client-shared/graphqlSchema/graphql';
+import { Coords } from 'terraso-client-shared/types';
 
 export const soilPitMethods = [
   'soilTexture',
@@ -145,3 +148,13 @@ export const DEPTH_PRESETS = [
   'CUSTOM',
   'NONE',
 ] as const satisfies readonly ProjectDepthIntervalPreset[];
+
+export type SoilIdParams = {
+  coords?: Coords;
+  siteId?: string;
+};
+
+export type SoilIdResults = {
+  locationBasedMatches: LocationBasedSoilMatch[];
+  dataBasedMatches: DataBasedSoilMatch[];
+};

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -31,6 +31,8 @@ import type {
 } from 'terraso-client-shared/graphqlSchema/graphql';
 import { Coords } from 'terraso-client-shared/types';
 
+export type LoadingState = 'loading' | 'error' | 'ready';
+
 export const soilPitMethods = [
   'soilTexture',
   'soilColor',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,10 +49,8 @@ export const isEquivalentCoords = (a?: Coords, b?: Coords): boolean => {
       a.latitude.toFixed(5) === b.latitude.toFixed(5) &&
       a.longitude.toFixed(5) === b.longitude.toFixed(5)
     );
-  } else if (a === undefined && b === undefined) {
-    return true;
   } else {
-    return false;
+    return a === undefined && b === undefined;
   }
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,8 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import { Coords } from 'terraso-client-shared/types';
+
 export const fromEntries = <K extends string | number | symbol, V>(
   entries: [K, V][],
 ) => Object.fromEntries(entries) as Record<K, V>;
@@ -40,6 +42,19 @@ export const mapValues = <T, U>(obj: Record<any, T>, f: (arg: T) => U) =>
 export const isValidLatitude = (lat: number) => lat >= -90 && lat <= 90;
 
 export const isValidLongitude = (lng: number) => lng >= -180 && lng <= 180;
+
+export const isEquivalentCoords = (a?: Coords, b?: Coords): boolean => {
+  if (a !== undefined && b !== undefined) {
+    return (
+      a.latitude.toFixed(5) === b.latitude.toFixed(5) &&
+      a.longitude.toFixed(5) === b.longitude.toFixed(5)
+    );
+  } else if (a !== undefined && b !== undefined) {
+    return true;
+  } else {
+    return false;
+  }
+};
 
 export const normalizeText = (text: string) =>
   text

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ export const isEquivalentCoords = (a?: Coords, b?: Coords): boolean => {
       a.latitude.toFixed(5) === b.latitude.toFixed(5) &&
       a.longitude.toFixed(5) === b.longitude.toFixed(5)
     );
-  } else if (a !== undefined && b !== undefined) {
+  } else if (a === undefined && b === undefined) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
## Description
(Creating from Ruxandra's work)
- Allow fetching soil matches from the Soil ID API with inputs from actual site data or location coordinates supplied by the app
- Cache most recent soil ID results for a site in Redux store
- Also track the loading state status

### Related Issues
Implements [#653](https://github.com/techmatters/terraso-product/issues/653)

### Verification steps
Look at the soil ID info screen for a given soil (need the corresponding mobile-client work)