### PR TITLE
refactor: Remove unnecessary type

### DIFF
--- a/src/account/accountSlice.ts
+++ b/src/account/accountSlice.ts
@@ -59,8 +59,6 @@ export type User = {
   preferences: Record<string, string>;
 };
 
-export type SimpleUserInfo = Omit<User, 'preferences'>;
-
 export const setHasAccessTokenAsync = createAsyncThunk(
   'account/setHasAccessTokenAsync',
   () => getToken(),


### PR DESCRIPTION
## Description
After adding this SimpleUserInfo type to client-shared, I found the UserFields type in mobile-client, which is basically what I wanted in the first place. It's the same exact shape, so I want to remove the SimpleUserInfo type I added here.

### Related Issues
As part of mobile-client [#1447](https://github.com/techmatters/terraso-mobile-client/issues/1447) 

