### PR TITLE
fix: soil id data caching

### DIFF
--- a/src/soilId/soilIdFunctions.test.tsx
+++ b/src/soilId/soilIdFunctions.test.tsx
@@ -1,0 +1,294 @@
+/*
+ * Copyright © 2021-2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import 'terraso-client-shared/tests/utils';
+
+import {
+  compareInterval,
+  degreeToPercent,
+  methodEnabled,
+  methodRequired,
+  overlaps,
+  sameDepth,
+  selectToPercent,
+  soilDataLabColorInput,
+  soilDataSlopePercent,
+  soilDataToIdInput,
+  soilIdEntryDataBased,
+  soilIdEntryForStatus,
+  soilIdEntryLocationBased,
+  soilIdKey,
+} from 'terraso-client-shared/soilId/soilIdFunctions';
+
+import { DepthDependentSoilData, SoilData } from './soilIdTypes';
+
+describe('methodEnabled', () => {
+  test('formats method names with the Enabled suffix', () => {
+    expect(methodEnabled('soilTexture')).toBe('soilTextureEnabled');
+  });
+});
+
+describe('methodRequired', () => {
+  test('formats method names with the Required suffix', () => {
+    expect(methodRequired('soilTexture')).toBe('soilTextureRequired');
+  });
+});
+
+describe('sameDepth', () => {
+  test('matches identical depth intervals', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const b = { depthInterval: { start: 1, end: 2 } };
+
+    expect(sameDepth(a)(b)).toBeTruthy();
+  });
+
+  test('rejects different starts', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const c = { depthInterval: { start: 10, end: 2 } };
+
+    expect(sameDepth(a)(c)).toBeFalsy();
+  });
+
+  test('rejects different ends', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const d = { depthInterval: { start: 1, end: 20 } };
+
+    expect(sameDepth(a)(d)).toBeFalsy();
+  });
+});
+
+describe('overlaps', () => {
+  test('accepts identical intervals', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const b = { depthInterval: { start: 1, end: 2 } };
+
+    expect(overlaps(a)(b)).toBeTruthy();
+  });
+
+  test('accepts intervals overlapping at the start', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const b = { depthInterval: { start: 0, end: 1.1 } };
+
+    expect(overlaps(a)(b)).toBeTruthy();
+  });
+
+  test('accepts intervals overlapping at the end', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const b = { depthInterval: { start: 1.9, end: 3 } };
+
+    expect(overlaps(a)(b)).toBeTruthy();
+  });
+
+  test('rejects intervals fully before', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const b = { depthInterval: { start: 2, end: 3 } };
+
+    expect(overlaps(a)(b)).toBeFalsy();
+  });
+
+  test('rejects intervals fully after', () => {
+    const a = { depthInterval: { start: 1, end: 2 } };
+    const b = { depthInterval: { start: 0, end: 1 } };
+
+    expect(overlaps(a)(b)).toBeFalsy();
+  });
+});
+
+describe('compareInterval', () => {
+  test('compares based on start value', () => {
+    const a = { depthInterval: { start: 0, end: 2 } };
+    const b = { depthInterval: { start: -1, end: 2 } };
+    const c = { depthInterval: { start: 1, end: 2 } };
+
+    expect(compareInterval(a, b)).toBeGreaterThan(0);
+    expect(compareInterval(a, a)).toEqual(0);
+    expect(compareInterval(a, c)).toBeLessThan(0);
+  });
+
+  test('can be used to sort intervals', () => {
+    const a = { depthInterval: { start: 0, end: 2 } };
+    const b = { depthInterval: { start: -1, end: 2 } };
+    const c = { depthInterval: { start: 1, end: 2 } };
+
+    const sorted = [c, b, a].sort(compareInterval);
+
+    expect(sorted).toEqual([b, a, c]);
+  });
+});
+
+describe('degreeToPercent', () => {
+  test('performs the calculation', () => {
+    expect(degreeToPercent(0)).toEqual(0);
+    expect(degreeToPercent(45)).toEqual(100);
+    expect(degreeToPercent(60)).toEqual(173);
+  });
+});
+
+describe('selectToPercent', () => {
+  test('maps all values', () => {
+    expect(selectToPercent('FLAT')).toEqual(0.0);
+    expect(selectToPercent('GENTLE')).toEqual(2);
+    expect(selectToPercent('HILLY')).toEqual(15);
+    expect(selectToPercent('MODERATE')).toEqual(5);
+    expect(selectToPercent('MODERATELY_STEEP')).toEqual(50);
+    expect(selectToPercent('ROLLING')).toEqual(10);
+    expect(selectToPercent('STEEP')).toEqual(30);
+    expect(selectToPercent('STEEPEST')).toEqual(100);
+    expect(selectToPercent('VERY_STEEP')).toEqual(60);
+  });
+});
+
+describe('soilDataSlopePercent', () => {
+  let data: SoilData;
+
+  beforeEach(() => {
+    data = {
+      slopeSteepnessPercent: undefined,
+      slopeSteepnessDegree: undefined,
+      slopeSteepnessSelect: undefined,
+    } as SoilData;
+  });
+
+  test('handles percentages', () => {
+    data.slopeSteepnessPercent = 100;
+    expect(soilDataSlopePercent(data)).toEqual(100);
+  });
+
+  test('handles degrees', () => {
+    data.slopeSteepnessDegree = 45;
+    expect(soilDataSlopePercent(data)).toEqual(100);
+  });
+
+  test('handles selections', () => {
+    data.slopeSteepnessSelect = 'VERY_STEEP';
+    expect(soilDataSlopePercent(data)).toEqual(60);
+  });
+});
+
+describe('soilDataLabColorInput', () => {
+  let data: DepthDependentSoilData;
+
+  beforeEach(() => {
+    data = {
+      colorHue: undefined,
+      colorValue: undefined,
+      colorChroma: undefined,
+    } as DepthDependentSoilData;
+  });
+
+  test('handles missing values', () => {
+    expect(soilDataLabColorInput(data)).toBeUndefined();
+
+    data.colorHue = 1;
+    expect(soilDataLabColorInput(data)).toBeUndefined();
+
+    data.colorValue = 1;
+    expect(soilDataLabColorInput(data)).toBeUndefined();
+
+    data.colorChroma = 1;
+    expect(soilDataLabColorInput(data)).toBeDefined();
+  });
+
+  test('applies the conversion math', () => {
+    data.colorHue = 0.5;
+    data.colorValue = 0.5;
+    data.colorChroma = 0.5;
+
+    const { L, A, B } = soilDataLabColorInput(data)!;
+    expect(L).toBeCloseTo(5.124);
+    expect(A).toBeCloseTo(3.437);
+    expect(B).toBeCloseTo(-0.784);
+  });
+});
+
+describe('soilDataToIdInput', () => {
+  let data: SoilData;
+
+  beforeEach(() => {
+    data = {
+      depthDependentData: [] as DepthDependentSoilData[],
+      slopeSteepnessDegree: undefined,
+      slopeSteepnessPercent: undefined,
+      slopeSteepnessSelect: undefined,
+    } as SoilData;
+  });
+
+  test('restructures data', () => {
+    data.slopeSteepnessDegree = 45;
+    data.depthDependentData = [
+      {
+        depthInterval: { start: 1, end: 2 },
+        colorHue: 0,
+        colorValue: 0,
+        colorChroma: 0,
+        rockFragmentVolume: 'VOLUME_0_1',
+        texture: 'CLAY',
+      },
+    ];
+    expect(soilDataToIdInput(data)).toEqual({
+      depthDependentData: [
+        {
+          depthInterval: { start: 1, end: 2 },
+          colorLAB: { L: 0, A: 0, B: 0 },
+          rockFragmentVolume: 'VOLUME_0_1',
+          texture: 'CLAY',
+        },
+      ],
+      slope: 100,
+    });
+  });
+});
+
+describe('soilIdKey', () => {
+  test('produces keys for coords and sites', () => {
+    expect(soilIdKey({ longitude: 1, latitude: 2 }, 'abc')).toBe('(1, 2) abc');
+  });
+
+  test('produces keys for coords', () => {
+    expect(soilIdKey({ longitude: 1, latitude: 2 })).toBe('(1, 2) ');
+  });
+});
+
+describe('soilIdEntryForStatus', () => {
+  test('produces an entry with the given status and empty matches', () => {
+    expect(soilIdEntryForStatus('ready')).toEqual({
+      status: 'ready',
+      dataBasedMatches: undefined,
+      locationBasedMatches: undefined,
+    });
+  });
+});
+
+describe('soilIdEntryLocationBased', () => {
+  test('produces an entry with ready status and the given matches', () => {
+    expect(soilIdEntryLocationBased(['match'] as any)).toEqual({
+      status: 'ready',
+      dataBasedMatches: undefined,
+      locationBasedMatches: ['match'],
+    });
+  });
+});
+
+describe('soilIdEntryDataBased', () => {
+  test('produces an entry with ready status and the given matches', () => {
+    expect(soilIdEntryDataBased(['match'] as any)).toEqual({
+      status: 'ready',
+      dataBasedMatches: ['match'],
+      locationBasedMatches: undefined,
+    });
+  });
+});

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -17,7 +17,9 @@
 
 import { mhvcToLab } from 'munsell';
 import {
+  DataBasedSoilMatch,
   LabColorInput,
+  LocationBasedSoilMatch,
   Maybe,
   SoilIdInputData,
   SoilIdInputDepthDependentData,
@@ -28,7 +30,9 @@ import {
   DepthDependentSoilData,
   DepthInterval,
   SoilData,
+  SoilIdEntry,
   SoilIdKey,
+  SoilIdStatus,
   SoilPitMethod,
 } from 'terraso-client-shared/soilId/soilIdTypes';
 import { Coords } from 'terraso-client-shared/types';
@@ -141,4 +145,28 @@ export const soilDepthDependentDataToIdInput = (
 
 export const soilIdKey = (coords: Coords, siteId?: string): SoilIdKey => {
   return `(${coords.longitude}, ${coords.latitude}) ${siteId}`;
+};
+
+export const soilIdEntryForStatus = (status: SoilIdStatus): SoilIdEntry => {
+  return {
+    status: status,
+  };
+};
+
+export const soilIdEntryLocationBased = (
+  matches: LocationBasedSoilMatch[],
+): SoilIdEntry => {
+  return {
+    locationBasedMatches: matches,
+    status: 'ready',
+  };
+};
+
+export const soilIdEntryDataBased = (
+  matches: DataBasedSoilMatch[],
+): SoilIdEntry => {
+  return {
+    dataBasedMatches: matches,
+    status: 'ready',
+  };
 };

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -28,8 +28,10 @@ import {
   DepthDependentSoilData,
   DepthInterval,
   SoilData,
+  SoilIdKey,
   SoilPitMethod,
 } from 'terraso-client-shared/soilId/soilIdTypes';
+import { Coords } from 'terraso-client-shared/types';
 
 export const methodEnabled = <T extends SoilPitMethod>(
   method: T,
@@ -135,4 +137,8 @@ export const soilDepthDependentDataToIdInput = (
     rockFragmentVolume: data.rockFragmentVolume,
     texture: data.texture,
   };
+};
+
+export const soilIdKey = (coords: Coords, siteId?: string): SoilIdKey => {
+  return `(${coords.longitude}, ${coords.latitude}) ${siteId}`;
 };

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -144,7 +144,7 @@ export const soilDepthDependentDataToIdInput = (
 };
 
 export const soilIdKey = (coords: Coords, siteId?: string): SoilIdKey => {
-  return `(${coords.longitude}, ${coords.latitude}) ${siteId}`;
+  return `(${coords.longitude}, ${coords.latitude}) ${siteId ?? ''}`;
 };
 
 export const soilIdEntryForStatus = (status: SoilIdStatus): SoilIdEntry => {

--- a/src/soilId/soilIdFunctions.ts
+++ b/src/soilId/soilIdFunctions.ts
@@ -69,31 +69,31 @@ export const selectToPercent = (
   switch (select) {
     /** 0 - 2% (flat) */
     case 'FLAT':
-      return 0.0;
+      return 0;
     /** 2 - 5% (gentle) */
     case 'GENTLE':
-      return 0.02;
+      return 2;
     /** 15 - 30% (hilly) */
     case 'HILLY':
-      return 0.15;
+      return 15;
     /** 5 - 10% (moderate) */
     case 'MODERATE':
-      return 0.05;
+      return 5;
     /** 50 - 60% (moderately steep) */
     case 'MODERATELY_STEEP':
-      return 0.5;
+      return 50;
     /** 10 - 15% (rolling) */
     case 'ROLLING':
-      return 0.1;
+      return 10;
     /** 30 - 50% (steep) */
     case 'STEEP':
-      return 0.3;
+      return 30;
     /** 100%+ (steepest) */
     case 'STEEPEST':
-      return 1.0;
+      return 100;
     /** 60 - 100% (very steep) */
     case 'VERY_STEEP':
-      return 0.6;
+      return 60;
   }
 };
 

--- a/src/soilId/soilIdHooks.ts
+++ b/src/soilId/soilIdHooks.ts
@@ -25,10 +25,8 @@ import {
 import { selectSoilData } from 'terraso-client-shared/selectors';
 import { selectSoilIdMatches } from 'terraso-client-shared/soilId/soilIdSelectors';
 import {
-  claimKey,
   fetchDataBasedSoilMatches,
   fetchLocationBasedSoilMatches,
-  releaseKey,
   soilDataToIdInput,
   soilIdKey,
   SoilIdStatus,
@@ -62,7 +60,7 @@ export const useSoilIdData = (
   const entry = useSelector(soilIdSelector);
   const entryPresent = Boolean(entry);
 
-  /* Side effect 1: load data if it's missing */
+  /* load data if it's missing */
   useEffect(() => {
     if (!entryPresent) {
       if (siteId && soilData) {
@@ -78,14 +76,6 @@ export const useSoilIdData = (
       }
     }
   }, [dispatch, coords, siteId, entryPresent, soilData]);
-
-  /* Side effect 2: record usage of keys in the soil ID cache */
-  useEffect(() => {
-    dispatch(claimKey(key));
-    return () => {
-      dispatch(releaseKey(key));
-    };
-  }, [dispatch, key]);
 
   return {
     locationBasedMatches: entry?.locationBasedMatches ?? [],

--- a/src/soilId/soilIdHooks.ts
+++ b/src/soilId/soilIdHooks.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { DEFAULT_SOIL_DATA } from 'terraso-client-shared/constants';
+import {
+  DataBasedSoilMatch,
+  LocationBasedSoilMatch,
+} from 'terraso-client-shared/graphqlSchema/graphql';
+import { selectSoilData } from 'terraso-client-shared/selectors';
+import { selectSoilIdMatches } from 'terraso-client-shared/soilId/soilIdSelectors';
+import {
+  claimKey,
+  fetchDataBasedSoilMatches,
+  fetchLocationBasedSoilMatches,
+  releaseKey,
+  soilDataToIdInput,
+  soilIdKey,
+  SoilIdStatus,
+} from 'terraso-client-shared/soilId/soilIdSlice';
+import type { SharedDispatch } from 'terraso-client-shared/store/store';
+import { Coords } from 'terraso-client-shared/types';
+
+/*
+ * Note that the soilId redux slice only supports a single cached value for soil ID data.
+ * If multiple components are passing different inputs to this hook simultaneously, it
+ * will not function correctly.
+ */
+export const useSoilIdData = (
+  coords: Coords,
+  siteId?: string,
+): {
+  locationBasedMatches: LocationBasedSoilMatch[];
+  dataBasedMatches: DataBasedSoilMatch[];
+  status: SoilIdStatus;
+} => {
+  const dispatch = useDispatch<SharedDispatch>();
+
+  /* We only need to select soil data for data-based matches. */
+  const soilDataSelector = siteId
+    ? selectSoilData(siteId)
+    : () => DEFAULT_SOIL_DATA;
+  const soilData = useSelector(soilDataSelector);
+
+  const key = soilIdKey(coords, siteId);
+  const soilIdSelector = selectSoilIdMatches(key);
+  const entry = useSelector(soilIdSelector);
+  const entryPresent = Boolean(entry);
+
+  /* Side effect 1: load data if it's missing */
+  useEffect(() => {
+    if (!entryPresent) {
+      if (siteId && soilData) {
+        dispatch(
+          fetchDataBasedSoilMatches({
+            coords,
+            siteId,
+            soilData: soilDataToIdInput(soilData),
+          }),
+        );
+      } else if (!siteId) {
+        dispatch(fetchLocationBasedSoilMatches(coords));
+      }
+    }
+  }, [dispatch, coords, siteId, entryPresent, soilData]);
+
+  /* Side effect 2: record usage of keys in the soil ID cache */
+  useEffect(() => {
+    dispatch(claimKey(key));
+    return () => {
+      dispatch(releaseKey(key));
+    };
+  }, [dispatch, key]);
+
+  return {
+    locationBasedMatches: entry?.locationBasedMatches ?? [],
+    dataBasedMatches: entry?.dataBasedMatches ?? [],
+    status: entry?.status ?? 'loading',
+  };
+};

--- a/src/soilId/soilIdHooks.ts
+++ b/src/soilId/soilIdHooks.ts
@@ -29,6 +29,7 @@ import {
   fetchLocationBasedSoilMatches,
   soilDataToIdInput,
   soilIdKey,
+  SoilIdResults,
   SoilIdStatus,
 } from 'terraso-client-shared/soilId/soilIdSlice';
 import type { SharedDispatch } from 'terraso-client-shared/store/store';
@@ -42,9 +43,7 @@ import { Coords } from 'terraso-client-shared/types';
 export const useSoilIdData = (
   coords: Coords,
   siteId?: string,
-): {
-  locationBasedMatches: LocationBasedSoilMatch[];
-  dataBasedMatches: DataBasedSoilMatch[];
+): SoilIdResults & {
   status: SoilIdStatus;
 } => {
   const dispatch = useDispatch<SharedDispatch>();

--- a/src/soilId/soilIdHooks.ts
+++ b/src/soilId/soilIdHooks.ts
@@ -18,10 +18,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DEFAULT_SOIL_DATA } from 'terraso-client-shared/constants';
-import {
-  DataBasedSoilMatch,
-  LocationBasedSoilMatch,
-} from 'terraso-client-shared/graphqlSchema/graphql';
 import { selectSoilData } from 'terraso-client-shared/selectors';
 import { selectSoilIdMatches } from 'terraso-client-shared/soilId/soilIdSelectors';
 import {

--- a/src/soilId/soilIdSelectors.ts
+++ b/src/soilId/soilIdSelectors.ts
@@ -15,10 +15,9 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { SharedState } from 'terraso-client-shared/store/store';
-
 import { SoilIdEntry } from 'terraso-client-shared/soilId/soilIdSlice';
 import { SoilIdKey } from 'terraso-client-shared/soilId/soilIdTypes';
+import { SharedState } from 'terraso-client-shared/store/store';
 
 export const selectSoilIdMatches =
   (key: SoilIdKey) =>

--- a/src/soilId/soilIdSelectors.ts
+++ b/src/soilId/soilIdSelectors.ts
@@ -15,13 +15,20 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+import {
+  DataBasedSoilMatch,
+  LocationBasedSoilMatch,
+} from 'terraso-client-shared/graphqlSchema/graphql';
 import { SharedState } from 'terraso-client-shared/store/store';
 
-export const selectSoilIdData = () => (state: SharedState) =>
-  state.soilId.soilIdData;
+import { SoilIdEntry } from './soilIdSlice';
+import { SoilIdKey } from './soilIdTypes';
 
-export const selectSoilIdInput = () => (state: SharedState) =>
-  state.soilId.soilIdParams;
-
-export const selectSoilIdStatus = () => (state: SharedState) =>
-  state.soilId.soilIdStatus;
+export const selectSoilIdLocationBasedMatches =
+  (key: SoilIdKey) =>
+  (state: SharedState): SoilIdEntry<LocationBasedSoilMatch> | undefined =>
+    state.soilId.locationBasedMatches[key];
+export const selectSoilIdDataBasedMatches =
+  (key: SoilIdKey) =>
+  (state: SharedState): SoilIdEntry<DataBasedSoilMatch> | undefined =>
+    state.soilId.dataBasedMatches[key];

--- a/src/soilId/soilIdSelectors.ts
+++ b/src/soilId/soilIdSelectors.ts
@@ -15,20 +15,12 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  DataBasedSoilMatch,
-  LocationBasedSoilMatch,
-} from 'terraso-client-shared/graphqlSchema/graphql';
 import { SharedState } from 'terraso-client-shared/store/store';
 
 import { SoilIdEntry } from './soilIdSlice';
 import { SoilIdKey } from './soilIdTypes';
 
-export const selectSoilIdLocationBasedMatches =
+export const selectSoilIdMatches =
   (key: SoilIdKey) =>
-  (state: SharedState): SoilIdEntry<LocationBasedSoilMatch> | undefined =>
-    state.soilId.locationBasedMatches[key];
-export const selectSoilIdDataBasedMatches =
-  (key: SoilIdKey) =>
-  (state: SharedState): SoilIdEntry<DataBasedSoilMatch> | undefined =>
-    state.soilId.dataBasedMatches[key];
+  (state: SharedState): SoilIdEntry | undefined =>
+    state.soilId.matches[key];

--- a/src/soilId/soilIdSelectors.ts
+++ b/src/soilId/soilIdSelectors.ts
@@ -17,8 +17,8 @@
 
 import { SharedState } from 'terraso-client-shared/store/store';
 
-import { SoilIdEntry } from './soilIdSlice';
-import { SoilIdKey } from './soilIdTypes';
+import { SoilIdEntry } from 'terraso-client-shared/soilId/soilIdSlice';
+import { SoilIdKey } from 'terraso-client-shared/soilId/soilIdTypes';
 
 export const selectSoilIdMatches =
   (key: SoilIdKey) =>

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -98,7 +98,7 @@ const soilIdSlice = createSlice({
     ) => {
       state.status = action.payload;
     },
-    useKey: (state, action: PayloadAction<SoilIdKey>) => {
+    claimKey: (state, action: PayloadAction<SoilIdKey>) => {
       const key = action.payload;
       state.usages[key] = state.usages[key] ?? 0 + 1;
     },
@@ -213,8 +213,8 @@ export const {
   setSoilData,
   setSoilIdStatus,
   updateProjectSettings,
-  useKey,
-  releaseKey
+  claimKey,
+  releaseKey,
 } = soilIdSlice.actions;
 
 export const fetchSoilDataForUser = createAsyncThunk(

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -212,9 +212,8 @@ const flushDataBasedMatches = (state: SoilState) => {
    * cached entries that are data-based since they aren't valid anymore.
    */
   Object.keys(state.matches)
-    .map(key => key as SoilIdKey)
-    .filter(key => state.matches[key].dataBasedMatches?.length)
-    .forEach(key => delete state.matches[key]);
+    .filter(key => state.matches[key as SoilIdKey].dataBasedMatches?.length)
+    .forEach(key => delete state.matches[key as SoilIdKey]);
 };
 
 export const {

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -54,7 +54,6 @@ export type SoilState = {
   status: LoadingState;
 
   matches: Record<SoilIdKey, SoilIdEntry>;
-  usages: Record<SoilIdKey, number>;
 };
 
 const initialState: SoilState = {
@@ -63,7 +62,6 @@ const initialState: SoilState = {
   status: 'loading',
 
   matches: {},
-  usages: {},
 };
 
 const soilIdSlice = createSlice({
@@ -97,25 +95,6 @@ const soilIdSlice = createSlice({
       action: PayloadAction<'loading' | 'error' | 'ready'>,
     ) => {
       state.status = action.payload;
-    },
-    claimKey: (state, action: PayloadAction<SoilIdKey>) => {
-      /* When a cache key is claimed, we increment a counter for that key. */
-      const key = action.payload;
-      state.usages[key] = (state.usages[key] ?? 0) + 1;
-    },
-    releaseKey: (state, action: PayloadAction<SoilIdKey>) => {
-      /*
-       * When a cache key is released, we check to see if it is no longer in use.
-       * If no more usages exist, we remove it from the matches cache.
-       */
-      const key = action.payload;
-      if (key in state.usages) {
-        const count = Math.max(0, state.usages[key] - 1);
-        if (count === 0) {
-          delete state.matches[key];
-        }
-        state.usages[key] = count;
-      }
     },
   },
   extraReducers: builder => {
@@ -221,8 +200,6 @@ export const {
   setSoilData,
   setSoilIdStatus,
   updateProjectSettings,
-  claimKey,
-  releaseKey,
 } = soilIdSlice.actions;
 
 export const fetchSoilDataForUser = createAsyncThunk(

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -100,7 +100,7 @@ const soilIdSlice = createSlice({
     },
     claimKey: (state, action: PayloadAction<SoilIdKey>) => {
       const key = action.payload;
-      state.usages[key] = state.usages[key] ?? 0 + 1;
+      state.usages[key] = (state.usages[key] ?? 0) + 1;
     },
     releaseKey: (state, action: PayloadAction<SoilIdKey>) => {
       const key = action.payload;

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -98,17 +98,11 @@ const soilIdSlice = createSlice({
     ) => {
       state.status = action.payload;
     },
-    useKey: (
-      state,
-      action: PayloadAction<SoilIdKey>,
-    ) => {
+    useKey: (state, action: PayloadAction<SoilIdKey>) => {
       const key = action.payload;
       state.usages[key] = state.usages[key] ?? 0 + 1;
     },
-    releaseKey: (
-      state,
-      action: PayloadAction<SoilIdKey>,
-    ) => {
+    releaseKey: (state, action: PayloadAction<SoilIdKey>) => {
       const key = action.payload;
       if (key in state.usages) {
         const count = Math.max(0, state.usages[key] - 1);

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -54,6 +54,7 @@ export type SoilState = {
   status: LoadingState;
 
   matches: Record<SoilIdKey, SoilIdEntry>;
+  usages: Record<SoilIdKey, number>;
 };
 
 const initialState: SoilState = {
@@ -62,6 +63,7 @@ const initialState: SoilState = {
   status: 'loading',
 
   matches: {},
+  usages: {},
 };
 
 const soilIdSlice = createSlice({
@@ -95,6 +97,26 @@ const soilIdSlice = createSlice({
       action: PayloadAction<'loading' | 'error' | 'ready'>,
     ) => {
       state.status = action.payload;
+    },
+    useKey: (
+      state,
+      action: PayloadAction<SoilIdKey>,
+    ) => {
+      const key = action.payload;
+      state.usages[key] = state.usages[key] ?? 0 + 1;
+    },
+    releaseKey: (
+      state,
+      action: PayloadAction<SoilIdKey>,
+    ) => {
+      const key = action.payload;
+      if (key in state.usages) {
+        const count = Math.max(0, state.usages[key] - 1);
+        if (count == 0) {
+          delete state.matches[key];
+        }
+        state.usages[key] = count;
+      }
     },
   },
   extraReducers: builder => {

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -99,10 +99,15 @@ const soilIdSlice = createSlice({
       state.status = action.payload;
     },
     claimKey: (state, action: PayloadAction<SoilIdKey>) => {
+      /* When a cache key is claimed, we increment a counter for that key. */
       const key = action.payload;
       state.usages[key] = (state.usages[key] ?? 0) + 1;
     },
     releaseKey: (state, action: PayloadAction<SoilIdKey>) => {
+      /*
+       * When a cache key is released, we check to see if it is no longer in use.
+       * If no more usages exist, we remove it from the matches cache.
+       */
       const key = action.payload;
       if (key in state.usages) {
         const count = Math.max(0, state.usages[key] - 1);
@@ -202,6 +207,10 @@ const soilIdSlice = createSlice({
 });
 
 const flushDataBasedMatches = (state: SoilState) => {
+  /*
+   * When soil ID input data changes (e.g. samples, intervals), we clear any
+   * cached entries that are data-based since they aren't valid anymore.
+   */
   Object.keys(state.matches)
     .map(key => key as SoilIdKey)
     .filter(key => state.matches[key].dataBasedMatches?.length)

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -213,6 +213,8 @@ export const {
   setSoilData,
   setSoilIdStatus,
   updateProjectSettings,
+  useKey,
+  releaseKey
 } = soilIdSlice.actions;
 
 export const fetchSoilDataForUser = createAsyncThunk(

--- a/src/soilId/soilIdSlice.ts
+++ b/src/soilId/soilIdSlice.ts
@@ -106,7 +106,7 @@ const soilIdSlice = createSlice({
       const key = action.payload;
       if (key in state.usages) {
         const count = Math.max(0, state.usages[key] - 1);
-        if (count == 0) {
+        if (count === 0) {
           delete state.matches[key];
         }
         state.usages[key] = count;

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -174,9 +174,11 @@ export const DEPTH_PRESETS = [
 ] as const satisfies readonly ProjectDepthIntervalPreset[];
 
 export type SoilIdParams = {
-  coords?: Coords;
+  coords: Coords;
   siteId?: string;
 };
+
+export type SoilIdKey = `(${number}, ${number}) ${string}`;
 
 export type SoilIdResults = {
   locationBasedMatches: LocationBasedSoilMatch[];

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -26,6 +26,7 @@ import type {
   SoilDataNode,
   SoilIdDepthDependentSoilDataRockFragmentVolumeChoices,
   SoilIdDepthDependentSoilDataTextureChoices,
+  SoilIdFailureReason,
   SoilIdProjectSoilSettingsDepthIntervalPresetChoices,
   SoilIdSoilDataSurfaceCracksSelectChoices,
 } from 'terraso-client-shared/graphqlSchema/graphql';
@@ -179,6 +180,14 @@ export type SoilIdParams = {
 };
 
 export type SoilIdKey = `(${number}, ${number}) ${string}`;
+
+export type SoilIdStatus = LoadingState | SoilIdFailureReason;
+
+export type SoilIdEntry = {
+  locationBasedMatches?: LocationBasedSoilMatch[];
+  dataBasedMatches?: DataBasedSoilMatch[];
+  status: SoilIdStatus;
+};
 
 export type SoilIdResults = {
   locationBasedMatches: LocationBasedSoilMatch[];

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -174,11 +174,6 @@ export const DEPTH_PRESETS = [
   'NONE',
 ] as const satisfies readonly ProjectDepthIntervalPreset[];
 
-export type SoilIdParams = {
-  coords: Coords;
-  siteId?: string;
-};
-
 export type SoilIdKey = `(${number}, ${number}) ${string}`;
 
 export type SoilIdStatus = LoadingState | SoilIdFailureReason;

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -31,7 +31,6 @@ import type {
   SoilIdSoilDataSurfaceCracksSelectChoices,
 } from 'terraso-client-shared/graphqlSchema/graphql';
 import { MethodRequired } from 'terraso-client-shared/soilId/soilIdSlice';
-import { Coords } from 'terraso-client-shared/types';
 
 export type LoadingState = 'loading' | 'error' | 'ready';
 


### PR DESCRIPTION
## Description

Fix issues caused by soil ID loading by replacing the one-off loading system with a data cache. Soil ID slice can now hold arbitrarily-many soil ID match sets, each with their own status. Refactor some nearby code for readability.

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
#1647

### Verification steps

See corresponding PR for mobile client.