### PR TITLE
refactor: Move SoilIdData type to client-shared (part 1)

### DIFF
--- a/src/soilId/soilIdHooks.ts
+++ b/src/soilId/soilIdHooks.ts
@@ -24,9 +24,8 @@ import {
   fetchDataBasedSoilMatches,
   fetchLocationBasedSoilMatches,
   soilDataToIdInput,
+  SoilIdData,
   soilIdKey,
-  SoilIdResults,
-  SoilIdStatus,
 } from 'terraso-client-shared/soilId/soilIdSlice';
 import type { SharedDispatch } from 'terraso-client-shared/store/store';
 import { Coords } from 'terraso-client-shared/types';
@@ -36,12 +35,7 @@ import { Coords } from 'terraso-client-shared/types';
  * If multiple components are passing different inputs to this hook simultaneously, it
  * will not function correctly.
  */
-export const useSoilIdData = (
-  coords: Coords,
-  siteId?: string,
-): SoilIdResults & {
-  status: SoilIdStatus;
-} => {
+export const useSoilIdData = (coords: Coords, siteId?: string): SoilIdData => {
   const dispatch = useDispatch<SharedDispatch>();
 
   /* We only need to select soil data for data-based matches. */

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -187,3 +187,5 @@ export type SoilIdResults = {
   locationBasedMatches: LocationBasedSoilMatch[];
   dataBasedMatches: DataBasedSoilMatch[];
 };
+
+export type SoilIdData = SoilIdResults & { status: SoilIdStatus };


### PR DESCRIPTION
## Description
Add `SoilIdData` type here so we can move it from mobile-client to client-shared.
This is follow-on refactoring to PR https://github.com/techmatters/terraso-mobile-client/pull/1688 

### Related Issues
Related to https://github.com/techmatters/terraso-product/issues/895
