### PR TITLE
feat: Update depth presets for Capri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "munsell": "^1.1.5",
         "react": "18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#bf1e75a03e5721f266a8189cd0f5371a6aa55d06",
+        "terraso-backend": "github:techmatters/terraso-backend#10de1414a43d651af3db55fbac521495d0e2976f",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13713,8 +13713,8 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#bf1e75a03e5721f266a8189cd0f5371a6aa55d06",
-      "integrity": "sha512-8syk+4e3qm5zQrt1R3mbUBosF8B7aSKskbWGI2MkBt4OHlJnywZQlQ+UNtof4dCprPyVm/2CV/QZiO0//LqiGg=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#10de1414a43d651af3db55fbac521495d0e2976f",
+      "integrity": "sha512-NWW+HEeIZxfo+RnsGoqGVtRrw0co6+lK9SY27IxLLvpce9YwVQT3Mpt4rUj3YhjKUYpeSs06VjePfMfoswCR1A=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "munsell": "^1.1.5",
         "react": "18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#b542062",
+        "terraso-backend": "github:techmatters/terraso-backend#9618c528cce18a9bface8e706219df1aa4452c78",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13713,7 +13713,8 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#b542062daed0b66b3149562474fbae18c889c633"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#9618c528cce18a9bface8e706219df1aa4452c78",
+      "integrity": "sha512-LdrjGU7nAaJHpMafZ/IiCBV8UYmnUMXFOxN67eWiHT34FU0FxCCSPdvNjuUKkXLSrcX//IF0IibJOcjB56x00Q=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "munsell": "^1.1.5",
         "react": "18.2.0",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#9618c528cce18a9bface8e706219df1aa4452c78",
+        "terraso-backend": "github:techmatters/terraso-backend#bf1e75a03e5721f266a8189cd0f5371a6aa55d06",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13713,8 +13713,8 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#9618c528cce18a9bface8e706219df1aa4452c78",
-      "integrity": "sha512-LdrjGU7nAaJHpMafZ/IiCBV8UYmnUMXFOxN67eWiHT34FU0FxCCSPdvNjuUKkXLSrcX//IF0IibJOcjB56x00Q=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#bf1e75a03e5721f266a8189cd0f5371a6aa55d06",
+      "integrity": "sha512-8syk+4e3qm5zQrt1R3mbUBosF8B7aSKskbWGI2MkBt4OHlJnywZQlQ+UNtof4dCprPyVm/2CV/QZiO0//LqiGg=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "munsell": "^1.1.5",
     "react": "18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#bf1e75a03e5721f266a8189cd0f5371a6aa55d06",
+    "terraso-backend": "github:techmatters/terraso-backend#10de1414a43d651af3db55fbac521495d0e2976f",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "munsell": "^1.1.5",
     "react": "18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#b542062",
+    "terraso-backend": "github:techmatters/terraso-backend#9618c528cce18a9bface8e706219df1aa4452c78",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "munsell": "^1.1.5",
     "react": "18.2.0",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#9618c528cce18a9bface8e706219df1aa4452c78",
+    "terraso-backend": "github:techmatters/terraso-backend#bf1e75a03e5721f266a8189cd0f5371a6aa55d06",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,14 +31,6 @@ import { fromEntries, mapEntries } from 'terraso-client-shared/utils';
 
 export const DEPTH_INTERVAL_PRESETS = mapEntries(
   {
-    LANDPKS: [
-      { start: 0, end: 10 },
-      { start: 10, end: 20 },
-      { start: 20, end: 50 },
-      { start: 50, end: 70 },
-      { start: 70, end: 100 },
-      { start: 100, end: 200 },
-    ],
     NRCS: [
       { start: 0, end: 5 },
       { start: 5, end: 15 },
@@ -47,10 +39,17 @@ export const DEPTH_INTERVAL_PRESETS = mapEntries(
       { start: 60, end: 100 },
       { start: 100, end: 200 },
     ],
+    BLM_STANDARD: [
+      { start: 0, end: 1 },
+      { start: 1, end: 10 },
+      { start: 10, end: 20 },
+      { start: 20, end: 50 },
+      { start: 50, end: 70 },
+    ],
   } as const,
   depthIntervals =>
     depthIntervals.map(depthInterval => ({ label: '', depthInterval })),
-) satisfies Record<'LANDPKS' | 'NRCS', readonly LabelledDepthInterval[]>;
+) satisfies Record<'NRCS' | 'BLM_STANDARD', readonly LabelledDepthInterval[]>;
 
 export const DEFAULT_ENABLED_SOIL_PIT_METHODS: SoilPitMethod[] = [
   'soilTexture',
@@ -83,12 +82,12 @@ export const DEFAULT_PROJECT_SETTINGS: ProjectSoilSettings = {
     ]),
   ),
   soilPitRequired: true,
-  depthIntervalPreset: 'LANDPKS',
+  depthIntervalPreset: 'NRCS',
   depthIntervals: [],
 };
 
 export const DEFAULT_SOIL_DATA: SoilData = {
   depthDependentData: [],
   depthIntervals: [],
-  depthIntervalPreset: 'LANDPKS',
+  depthIntervalPreset: 'NRCS',
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const DEPTH_INTERVAL_PRESETS = mapEntries(
       { start: 60, end: 100 },
       { start: 100, end: 200 },
     ],
-    BLM_STANDARD: [
+    BLM: [
       { start: 0, end: 1 },
       { start: 1, end: 10 },
       { start: 10, end: 20 },
@@ -49,7 +49,7 @@ export const DEPTH_INTERVAL_PRESETS = mapEntries(
   } as const,
   depthIntervals =>
     depthIntervals.map(depthInterval => ({ label: '', depthInterval })),
-) satisfies Record<'NRCS' | 'BLM_STANDARD', readonly LabelledDepthInterval[]>;
+) satisfies Record<'NRCS' | 'BLM', readonly LabelledDepthInterval[]>;
 
 export const DEFAULT_ENABLED_SOIL_PIT_METHODS: SoilPitMethod[] = [
   'soilTexture',

--- a/src/selectors.test.ts
+++ b/src/selectors.test.ts
@@ -134,7 +134,7 @@ const createSoilData = (
     [site.id]: {
       depthDependentData: [],
       depthIntervals: [],
-      depthIntervalPreset: 'LANDPKS',
+      depthIntervalPreset: 'NRCS',
       ...defaults,
     },
   };
@@ -147,7 +147,7 @@ const createProjectSettings = (
   return {
     [project.id]: {
       // carbonatesRequired: false,
-      depthIntervalPreset: 'LANDPKS',
+      depthIntervalPreset: 'NRCS',
       depthIntervals: [],
       // electricalConductivityRequired: false,
       // landUseLandCoverRequired: false,
@@ -402,7 +402,7 @@ test('select predefined project selector', () => {
   const site = generateSite({ project });
   const soilData = createSoilData(site);
   const projectSettings = createProjectSettings(project, {
-    depthIntervalPreset: 'LANDPKS',
+    depthIntervalPreset: 'NRCS',
   });
 
   const aggregatedIntervals = renderSelectorHook(
@@ -416,7 +416,7 @@ test('select predefined project selector', () => {
   expect(
     aggregatedIntervals.map(({ interval: { depthInterval } }) => depthInterval),
   ).toStrictEqual(
-    DEPTH_INTERVAL_PRESETS['LANDPKS'].map(({ depthInterval }) => depthInterval),
+    DEPTH_INTERVAL_PRESETS['NRCS'].map(({ depthInterval }) => depthInterval),
   );
 });
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -225,8 +225,8 @@ export const selectUserRoleProject = createSelector(
 
 const projectIntervals = (settings: ProjectSoilSettings) => {
   switch (settings.depthIntervalPreset) {
-    case 'LANDPKS':
     case 'NRCS':
+    case 'BLM_STANDARD':
       return DEPTH_INTERVAL_PRESETS[settings.depthIntervalPreset];
     case 'CUSTOM':
       return settings.depthIntervals;
@@ -237,8 +237,8 @@ const projectIntervals = (settings: ProjectSoilSettings) => {
 
 const sitePresetIntervals = (soilData: SoilData) => {
   switch (soilData.depthIntervalPreset) {
-    case 'LANDPKS':
     case 'NRCS':
+    case 'BLM_STANDARD':
       return DEPTH_INTERVAL_PRESETS[soilData.depthIntervalPreset];
     default:
       return [];

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -226,7 +226,7 @@ export const selectUserRoleProject = createSelector(
 const projectIntervals = (settings: ProjectSoilSettings) => {
   switch (settings.depthIntervalPreset) {
     case 'NRCS':
-    case 'BLM_STANDARD':
+    case 'BLM':
       return DEPTH_INTERVAL_PRESETS[settings.depthIntervalPreset];
     case 'CUSTOM':
       return settings.depthIntervals;
@@ -238,7 +238,7 @@ const projectIntervals = (settings: ProjectSoilSettings) => {
 const sitePresetIntervals = (soilData: SoilData) => {
   switch (soilData.depthIntervalPreset) {
     case 'NRCS':
-    case 'BLM_STANDARD':
+    case 'BLM':
       return DEPTH_INTERVAL_PRESETS[soilData.depthIntervalPreset];
     default:
       return [];

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -167,8 +167,8 @@ export const surfaceCracks = [
 export type ProjectDepthIntervalPreset =
   SoilIdProjectSoilSettingsDepthIntervalPresetChoices;
 export const DEPTH_PRESETS = [
-  'LANDPKS',
   'NRCS',
+  'BLM_STANDARD',
   'CUSTOM',
   'NONE',
 ] as const satisfies readonly ProjectDepthIntervalPreset[];

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -168,7 +168,7 @@ export type ProjectDepthIntervalPreset =
   SoilIdProjectSoilSettingsDepthIntervalPresetChoices;
 export const DEPTH_PRESETS = [
   'NRCS',
-  'BLM_STANDARD',
+  'BLM',
   'CUSTOM',
   'NONE',
 ] as const satisfies readonly ProjectDepthIntervalPreset[];


### PR DESCRIPTION
For depth presets:
- remove LandPKS
- add BLM monitoring standard
- make NRCS the default
- update tests

### Related Issues
Client-shared part to address [#1541](https://github.com/techmatters/terraso-mobile-client/issues/1541)
