### PR TITLE
fix: use createSelector to avoid redux selector warning

### DIFF
--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -333,15 +333,17 @@ export const useSiteSoilIntervals = (siteId: string): AggregatedInterval[] => {
   );
 };
 
-export const selectDepthDependentData =
-  ({
-    siteId,
-    depthInterval,
-  }: {
-    siteId: string;
-    depthInterval: { depthInterval: DepthInterval };
-  }) =>
-  (state: SharedState): DepthDependentSoilData =>
-    selectSoilData(siteId)(state).depthDependentData.find(
-      sameDepth(depthInterval),
-    ) ?? { depthInterval: depthInterval.depthInterval };
+export const selectDepthDependentData = ({
+  siteId,
+  depthInterval,
+}: {
+  siteId: string;
+  depthInterval: { depthInterval: DepthInterval };
+}): (state: SharedState) => DepthDependentSoilData =>
+  createSelector(
+    selectSoilData(siteId),
+    soilData =>
+      soilData.depthDependentData.find(sameDepth(depthInterval)) ?? {
+        depthInterval: depthInterval.depthInterval,
+      } as DepthDependentSoilData,
+  );

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -339,11 +339,12 @@ export const selectDepthDependentData = ({
 }: {
   siteId: string;
   depthInterval: { depthInterval: DepthInterval };
-}): (state: SharedState) => DepthDependentSoilData =>
+}): ((state: SharedState) => DepthDependentSoilData) =>
   createSelector(
     selectSoilData(siteId),
     soilData =>
-      soilData.depthDependentData.find(sameDepth(depthInterval)) ?? {
+      soilData.depthDependentData.find(sameDepth(depthInterval)) ??
+      ({
         depthInterval: depthInterval.depthInterval,
-      } as DepthDependentSoilData,
+      } as DepthDependentSoilData),
   );


### PR DESCRIPTION
## Description

Rewrite `selectDepthDependentData` to use `createSelector` rather than chaining selectors inline. The `selectDepthDependentData` selector was causing a warning because of its internal use of `selectSoilData`. Redux recommends using the `createSelector` wrapper when chaining selectors together to avoid unnecessary re-renders. 

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #1322

### Verification steps

Open the application in developer mode and observe that the warning no longer spews to the console on the home screen or site screens.