### PR TITLE
feat: expose pushSoilData endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#7b7346d",
+        "terraso-backend": "github:techmatters/terraso-backend#a04af27",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13685,7 +13685,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#7b7346db6941a03eb67de9d6cdbd8e915b7acb18"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#a04af27466cb1251033ef163b7dde8144f4439dc"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#0a4e249",
+        "terraso-backend": "github:techmatters/terraso-backend#7b7346d",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13685,8 +13685,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#b61c60caf963a400bffa8016cb6f894d5d9d72b4",
-      "integrity": "sha512-rM6ZXO+dX5GT3QuERDJ5PW03O1buJdD7DOkFiMnKbvQobAT+L71NypMKsZrcfxi4+6gT2dYo1j/5EmkFQxVoJQ=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#7b7346db6941a03eb67de9d6cdbd8e915b7acb18"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#8360648",
+        "terraso-backend": "github:techmatters/terraso-backend#74fc2fc",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13685,7 +13685,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#8360648b999d0d9bdc72b5a9ebab273f94501232"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#74fc2fc640d86729ecacc74d6d450e0e5657173a"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#a04af27",
+        "terraso-backend": "github:techmatters/terraso-backend#a60d193",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13685,7 +13685,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#a04af27466cb1251033ef163b7dde8144f4439dc"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#a60d193a4319457c03a015d9534579061c1785d4"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#a60d193",
+        "terraso-backend": "github:techmatters/terraso-backend#8360648",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -13685,7 +13685,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#a60d193a4319457c03a015d9534579061c1785d4"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#8360648b999d0d9bdc72b5a9ebab273f94501232"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#8360648",
+    "terraso-backend": "github:techmatters/terraso-backend#74fc2fc",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#a04af27",
+    "terraso-backend": "github:techmatters/terraso-backend#a60d193",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#0a4e249",
+    "terraso-backend": "github:techmatters/terraso-backend#7b7346d",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#a60d193",
+    "terraso-backend": "github:techmatters/terraso-backend#8360648",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#7b7346d",
+    "terraso-backend": "github:techmatters/terraso-backend#a04af27",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/src/soilId/soilDataFragments.ts
+++ b/src/soilId/soilDataFragments.ts
@@ -120,3 +120,17 @@ export const depthDependentSoilData = /* GraphQL */ `
     carbonates
   }
 `;
+
+export const soilDataPushEntryResult = /* GraphQL */ `
+  fragment soilDataPushEntryResult on SoilDataPushEntryResult {
+    __typename
+    ... on SoilDataPushEntryFailure {
+      reason
+    }
+    ... on SoilDataPushEntrySuccess {
+      soilData {
+        ...soilData
+      }
+    }
+  }
+`;

--- a/src/soilId/soilDataService.ts
+++ b/src/soilId/soilDataService.ts
@@ -35,17 +35,6 @@ import {
   collapseMaps,
 } from 'terraso-client-shared/terrasoApi/utils';
 
-const collapseSoilDataPushEntry = (result: SoilDataPushEntryResultFragment) => {
-  if (result.__typename !== 'SoilDataPushEntrySuccess') return result;
-
-  const { site, ...resultWithoutSite } = result;
-
-  return {
-    ...resultWithoutSite,
-    soilData: result.site.soilData,
-  };
-};
-
 export const fetchSoilDataForUser = async (userId: string) => {
   const query = graphql(`
     query userSoilData($id: ID!) {
@@ -266,8 +255,5 @@ export const pushSoilData = async (depthInterval: SoilDataPushInput) => {
   `);
 
   const resp = await terrasoApi.requestGraphQL(query, { input: depthInterval });
-  return resp.pushSoilData.results.map(entry => ({
-    ...entry,
-    result: collapseSoilDataPushEntry(entry.result),
-  }))!;
+  return resp.pushSoilData.results;
 };

--- a/src/soilId/soilDataService.ts
+++ b/src/soilId/soilDataService.ts
@@ -22,7 +22,6 @@ import type {
   ProjectSoilSettingsUpdateDepthIntervalMutationInput,
   ProjectSoilSettingsUpdateMutationInput,
   SoilDataDeleteDepthIntervalMutationInput,
-  SoilDataPushEntryResultFragment,
   SoilDataPushInput,
   SoilDataUpdateDepthIntervalMutationInput,
   SoilDataUpdateMutationInput,

--- a/src/soilId/soilDataService.ts
+++ b/src/soilId/soilDataService.ts
@@ -22,6 +22,7 @@ import type {
   ProjectSoilSettingsUpdateDepthIntervalMutationInput,
   ProjectSoilSettingsUpdateMutationInput,
   SoilDataDeleteDepthIntervalMutationInput,
+  SoilDataPushInput,
   SoilDataUpdateDepthIntervalMutationInput,
   SoilDataUpdateMutationInput,
 } from 'terraso-client-shared/graphqlSchema/graphql';
@@ -235,4 +236,33 @@ export const deleteProjectDepthInterval = async (
 
   const resp = await terrasoApi.requestGraphQL(query, { input: depthInterval });
   return resp.deleteProjectSoilSettingsDepthInterval.projectSoilSettings!;
+};
+
+export const pushSoilData = async (depthInterval: SoilDataPushInput) => {
+  const query = graphql(`
+    mutation pushSoilData($input: SoilDataPushInput!) {
+      pushSoilData(input: $input) {
+        results {
+          siteId
+          result {
+            __typename
+            ... on SoilDataPushEntryFailure {
+              reason
+            }
+            ... on SoilDataPushEntrySuccess {
+              site {
+                soilData {
+                  ...soilData
+                }
+              }
+            }
+          }
+        }
+        errors
+      }
+    }
+  `);
+
+  const resp = await terrasoApi.requestGraphQL(query, { input: depthInterval });
+  return resp.pushSoilData.results!;
 };

--- a/src/soilId/soilIdFragments.ts
+++ b/src/soilId/soilIdFragments.ts
@@ -98,3 +98,19 @@ export const dataBasedSoilMatches = /* GraphQL */ `
     }
   }
 `;
+
+export const soilDataPushEntryResult = /* GraphQL */ `
+  fragment soilDataPushEntryResult on SoilDataPushEntryResult {
+    __typename
+    ... on SoilDataPushEntryFailure {
+      reason
+    }
+    ... on SoilDataPushEntrySuccess {
+      site {
+        soilData {
+          ...soilData
+        }
+      }
+    }
+  }
+`;

--- a/src/soilId/soilIdFragments.ts
+++ b/src/soilId/soilIdFragments.ts
@@ -98,19 +98,3 @@ export const dataBasedSoilMatches = /* GraphQL */ `
     }
   }
 `;
-
-export const soilDataPushEntryResult = /* GraphQL */ `
-  fragment soilDataPushEntryResult on SoilDataPushEntryResult {
-    __typename
-    ... on SoilDataPushEntryFailure {
-      reason
-    }
-    ... on SoilDataPushEntrySuccess {
-      site {
-        soilData {
-          ...soilData
-        }
-      }
-    }
-  }
-`;


### PR DESCRIPTION
## Description
Shouldn't be merged until [associated backend PR](https://github.com/techmatters/terraso-backend/pull/1472) is merged.

@tm-ruxandra wasn't sure what data you wanted exposed in the response, right now it just sends back all the soil data for each site queried, but if you aren't going to use that data at all we can omit it to save the bandwidth