### PR TITLE
refactor: Add account slice action to add to cache of users

### DIFF
--- a/src/account/accountSlice.ts
+++ b/src/account/accountSlice.ts
@@ -132,6 +132,10 @@ export const userSlice = createSlice({
       ...state,
       hasToken: action.payload,
     }),
+    addUserToCache: (state, action: PayloadAction<User>) => {
+      addUser(state, action.payload);
+      return state;
+    },
   },
 
   extraReducers: builder => {
@@ -283,7 +287,8 @@ export const userSlice = createSlice({
   },
 });
 
-export const { setCurrentUser, setHasToken } = userSlice.actions;
+export const { setCurrentUser, setHasToken, addUserToCache } =
+  userSlice.actions;
 
 export default userSlice.reducer;
 


### PR DESCRIPTION
## Description
This is so that when we get a user from the backend, we can add it to the redux state's cache of users.
This will allow us to pass a userId to the AddUserToProjectRoleScreen instead of the User object.
Which will allow the screen to detect if the user has been deleted from the system when a pull occurs.

### Related Issues
Part 1 to address #2289