### PR TITLE
chore: update package-lock after package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#fac222b",
+        "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
         "uuid": "^11.1.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#fac222b",
+    "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
     "uuid": "^11.1.0"
   },
   "scripts": {


### PR DESCRIPTION
## Description
I'd forgotten to run `npm install` after updating the backend version commit hash in package.json in [PR 1328](https://github.com/techmatters/terraso-client-shared/pull/1328). So do that.

### Related Issues
Required for https://github.com/techmatters/terraso-backend/issues/1618
