### PR TITLE
fix: Update backend dependency in package-lock.json correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#fac222b",
+        "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
         "uuid": "^11.1.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14080,7 +14080,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#fac222bd10eeac0176a2040e9b09449e84d0a693"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#43c94f46514501d8d4ed853b0d11e00f74418411"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#fac222b",
+    "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
     "uuid": "^11.1.0"
   },
   "scripts": {


### PR DESCRIPTION
## Description
One more change here -- needed to run `npm update terraso-backend` to update the commit hash in the `package-lock.json` dependency tree

### Related Issues
Required for https://github.com/techmatters/terraso-backend/issues/1618
Follow-on to PR https://github.com/techmatters/terraso-mobile-client/pull/2939 