### PR TITLE
fix: Revert uuid back to 10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
         "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
-        "uuid": "^11.1.0"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.27.0",
@@ -14678,16 +14678,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
     "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
-    "uuid": "^11.1.0"
+    "uuid": "^10.0.0"
   },
   "scripts": {
     "generate-types": "graphql-codegen",


### PR DESCRIPTION
## Description
mobile-client has uuid v 10.0.0 and can't be updated until we fix a jest problem
This keeps the two in sync so we can build mobile-client with current version of shared client.


### Related Issues
Test failure: https://github.com/techmatters/terraso-mobile-client/actions/runs/15005443651/job/42162785107?pr=2939
Potential solution at https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149