### PR TITLE
fix: Use uuid 11.1.0 again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
         "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.27.0",
@@ -14678,16 +14678,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
     "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
-    "uuid": "^10.0.0"
+    "uuid": "^11.1.0"
   },
   "scripts": {
     "generate-types": "graphql-codegen",


### PR DESCRIPTION
Revert "fix: Revert uuid back to 10.0.0"

This reverts commit 2ab8c9db59111f60c6b83b01ee3968c2234a1852.

## Description
- The github workflows passed when updating mobile-client to uuid 11.1.0 alongside this change to client-shared. See https://github.com/techmatters/terraso-mobile-client/pull/2939/files

Uncertainties:
- I'm not entirely sure what was causing the failure
- I didn't check if using client-shared with the updated uuid 11 would cause issues on web-client though.

### Related Issues
Tangentially related to https://github.com/techmatters/terraso-backend/issues/1618 in that we are just trying to bump mobile-client's dependency on client-shared, and were running into issues with the uuid version 

### Verification steps
Mobile-client workflow steps pass when using this and updating uuid to 11
