### PR TITLE
feat: Updates to enable global soil id functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
+        "terraso-backend": "github:techmatters/terraso-backend#adda724350d6736f92c0011205bb1c85271bc8ca",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -14080,7 +14080,8 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#43c94f46514501d8d4ed853b0d11e00f74418411"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#adda724350d6736f92c0011205bb1c85271bc8ca",
+      "integrity": "sha512-Zov4Xs4aCioya6+nJAPRcCRabYRES/4ocwFX0MBp2CiKWkVu0RtLja1zlCsP8yaRafIzoCIndEif6ZwlthKE+w=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#43c94f4",
+    "terraso-backend": "github:techmatters/terraso-backend#adda724350d6736f92c0011205bb1c85271bc8ca",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/src/soilId/soilIdFragments.ts
+++ b/src/soilId/soilIdFragments.ts
@@ -29,6 +29,7 @@ export const soilInfo = /* GraphQL */ `
       taxonomySubgroup
       description
       fullDescriptionUrl
+      management
     }
 
     ecologicalSite {
@@ -63,23 +64,9 @@ export const soilIdFailure = /* GraphQL */ `
   }
 `;
 
-export const locationBasedSoilMatches = /* GraphQL */ `
-  fragment locationBasedSoilMatches on LocationBasedSoilMatches {
-    matches {
-      dataSource
-      distanceToNearestMapUnitM
-      match {
-        ...soilMatchInfo
-      }
-      soilInfo {
-        ...soilInfo
-      }
-    }
-  }
-`;
-
 export const dataBasedSoilMatches = /* GraphQL */ `
   fragment dataBasedSoilMatches on DataBasedSoilMatches {
+    dataRegion
     matches {
       dataSource
       distanceToNearestMapUnitM

--- a/src/soilId/soilIdFragments.ts
+++ b/src/soilId/soilIdFragments.ts
@@ -29,7 +29,6 @@ export const soilInfo = /* GraphQL */ `
       taxonomySubgroup
       description
       fullDescriptionUrl
-      management
     }
 
     ecologicalSite {

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -20,24 +20,6 @@ import { SoilIdInputData } from 'terraso-client-shared/graphqlSchema/graphql';
 import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import { Coords } from 'terraso-client-shared/types';
 
-export const fetchLocationBasedSoilMatches = async (coords: Coords) => {
-  const query = graphql(`
-    query locationBasedSoilMatches($latitude: Float!, $longitude: Float!) {
-      soilId {
-        locationBasedSoilMatches(latitude: $latitude, longitude: $longitude) {
-          __typename
-          ...soilIdFailure
-          ...locationBasedSoilMatches
-        }
-      }
-    }
-  `);
-
-  return terrasoApi
-    .requestGraphQL(query, coords)
-    .then(({ soilId }) => soilId.locationBasedSoilMatches);
-};
-
 export const fetchDataBasedSoilMatches = async (
   coords: Coords,
   soilData: SoilIdInputData,


### PR DESCRIPTION
## Description
Make updates to client-shared that are required for global 

- Update backend dependency to latest commit
- Remove references to `locationBasedSoilMatches`
- Add `dataRegion` to `dataBasedSoilMatches`

FYI `management` will be handled in the client, so not adding it to the fragment

### Related Issues
Required to address https://github.com/techmatters/terraso-mobile-client/issues/2670, https://github.com/techmatters/terraso-mobile-client/issues/2776, https://github.com/techmatters/terraso-mobile-client/issues/2777, https://github.com/techmatters/terraso-mobile-client/issues/2778, https://github.com/techmatters/terraso-mobile-client/issues/2847, https://github.com/techmatters/terraso-mobile-client/issues/2927

