### PR TITLE
refactor: Export SoilMatch type (rename DataBasedSoilMatch)

### DIFF
--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -16,6 +16,8 @@
  */
 
 import type {
+  DataBasedSoilMatch,
+  DataBasedSoilMatches,
   DepthDependentSoilDataNode,
   DepthInterval,
   ProjectDepthIntervalNode,
@@ -176,3 +178,9 @@ export const DEPTH_PRESETS = [
   'CUSTOM',
   'NONE',
 ] as const satisfies readonly ProjectDepthIntervalPreset[];
+
+// The backend previously had "DataBasedSoilMatch" and "LocationBasedSoilMatch" types,
+// but both are now under the name "DataBasedSoilMatch". For clarity in the client,
+// use the name "SoilMatch".
+export type SoilMatch = DataBasedSoilMatch;
+export type SoilMatches = DataBasedSoilMatches;


### PR DESCRIPTION
Because we no longer have the concept of a `LocationBasedSoilMatch`, I now find the name `DataBasedSoilMatch` kind of confusing, and think it'll be clearer if at least the mobile client uses a`SoilMatch` type instead. So export that type in client-shared for use in mobile-client.

### Related Issues
Addresses part of https://github.com/techmatters/terraso-product/issues/1280