### PR TITLE
fix: Update backend to version with 1.2 and 1.3 endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#68ca9ace09caced2cb31cfa7d1988d1675561c4c",
+        "terraso-backend": "github:techmatters/terraso-backend#05bacc65da4c16e0c13688449d066789f96b0c54",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -14080,8 +14080,8 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#68ca9ace09caced2cb31cfa7d1988d1675561c4c",
-      "integrity": "sha512-Q2dtTnuI7UGOHXOJvKj4YdlqJY6qypMtEwlD0yj7jmstWsCa3nSKSXHVdfVE5KBDoEnN7dFoF1KKfJf2yjfqRw=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#05bacc65da4c16e0c13688449d066789f96b0c54",
+      "integrity": "sha512-3VWR97FTSQnnOPa3GD8HtY2sQcFsmO1Vu8Ay95OJwr3wzCpnjLGzckfqejotPjrrczDEhFPru3Lk/XFRU04Zhg=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-redux": "^8.1.3",
-        "terraso-backend": "github:techmatters/terraso-backend#05bacc65da4c16e0c13688449d066789f96b0c54",
+        "terraso-backend": "github:techmatters/terraso-backend#cc3450e62a882464a782c896626ad90609304f8e",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -14080,7 +14080,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#05bacc65da4c16e0c13688449d066789f96b0c54",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#cc3450e62a882464a782c896626ad90609304f8e",
       "integrity": "sha512-3VWR97FTSQnnOPa3GD8HtY2sQcFsmO1Vu8Ay95OJwr3wzCpnjLGzckfqejotPjrrczDEhFPru3Lk/XFRU04Zhg=="
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#68ca9ace09caced2cb31cfa7d1988d1675561c4c",
+    "terraso-backend": "github:techmatters/terraso-backend#05bacc65da4c16e0c13688449d066789f96b0c54",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-redux": "^8.1.3",
-    "terraso-backend": "github:techmatters/terraso-backend#05bacc65da4c16e0c13688449d066789f96b0c54",
+    "terraso-backend": "github:techmatters/terraso-backend#cc3450e62a882464a782c896626ad90609304f8e",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/src/soilId/soilIdFragments.ts
+++ b/src/soilId/soilIdFragments.ts
@@ -63,6 +63,28 @@ export const soilIdFailure = /* GraphQL */ `
   }
 `;
 
+export const soilMatches = /* GraphQL */ `
+  fragment soilMatches on SoilMatches {
+    dataRegion
+    matches {
+      dataSource
+      distanceToNearestMapUnitM
+      locationMatch {
+        ...soilMatchInfo
+      }
+      dataMatch {
+        ...soilMatchInfo
+      }
+      combinedMatch {
+        ...soilMatchInfo
+      }
+      soilInfo {
+        ...soilInfo
+      }
+    }
+  }
+`;
+
 export const dataBasedSoilMatches = /* GraphQL */ `
   fragment dataBasedSoilMatches on DataBasedSoilMatches {
     dataRegion

--- a/src/soilId/soilIdFragments.ts
+++ b/src/soilId/soilIdFragments.ts
@@ -84,25 +84,3 @@ export const soilMatches = /* GraphQL */ `
     }
   }
 `;
-
-export const dataBasedSoilMatches = /* GraphQL */ `
-  fragment dataBasedSoilMatches on DataBasedSoilMatches {
-    dataRegion
-    matches {
-      dataSource
-      distanceToNearestMapUnitM
-      locationMatch {
-        ...soilMatchInfo
-      }
-      dataMatch {
-        ...soilMatchInfo
-      }
-      combinedMatch {
-        ...soilMatchInfo
-      }
-      soilInfo {
-        ...soilInfo
-      }
-    }
-  }
-`;

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -25,20 +25,16 @@ export const fetchDataBasedSoilMatches = async (
   soilData: SoilIdInputData,
 ) => {
   const query = graphql(`
-    query dataBasedSoilMatches(
+    query soilMatches(
       $latitude: Float!
       $longitude: Float!
       $data: SoilIdInputData!
     ) {
       soilId {
-        dataBasedSoilMatches(
-          latitude: $latitude
-          longitude: $longitude
-          data: $data
-        ) {
+        soilMatches(latitude: $latitude, longitude: $longitude, data: $data) {
           __typename
           ...soilIdFailure
-          ...dataBasedSoilMatches
+          ...soilMatches
         }
       }
     }
@@ -46,5 +42,5 @@ export const fetchDataBasedSoilMatches = async (
 
   return terrasoApi
     .requestGraphQL(query, { ...coords, data: soilData })
-    .then(({ soilId }) => soilId.dataBasedSoilMatches);
+    .then(({ soilId }) => soilId.soilMatches);
 };

--- a/src/soilId/soilIdService.ts
+++ b/src/soilId/soilIdService.ts
@@ -20,7 +20,7 @@ import { SoilIdInputData } from 'terraso-client-shared/graphqlSchema/graphql';
 import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import { Coords } from 'terraso-client-shared/types';
 
-export const fetchDataBasedSoilMatches = async (
+export const fetchSoilMatches = async (
   coords: Coords,
   soilData: SoilIdInputData,
 ) => {

--- a/src/soilId/soilIdTypes.ts
+++ b/src/soilId/soilIdTypes.ts
@@ -16,8 +16,6 @@
  */
 
 import type {
-  DataBasedSoilMatch,
-  DataBasedSoilMatches,
   DepthDependentSoilDataNode,
   DepthInterval,
   ProjectDepthIntervalNode,
@@ -178,9 +176,3 @@ export const DEPTH_PRESETS = [
   'CUSTOM',
   'NONE',
 ] as const satisfies readonly ProjectDepthIntervalPreset[];
-
-// The backend previously had "DataBasedSoilMatch" and "LocationBasedSoilMatch" types,
-// but both are now under the name "DataBasedSoilMatch". For clarity in the client,
-// use the name "SoilMatch".
-export type SoilMatch = DataBasedSoilMatch;
-export type SoilMatches = DataBasedSoilMatches;


### PR DESCRIPTION
## Description
To fix the issue where the new backend is incompatible with both 1.2 and 1.3 clients simultaneously (details [in slack here](https://tech-matters.slack.com/archives/C0376RCCXD2/p1752170651976809))