### PR TITLE
build: bump terraso-backend pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#2026-04-21.0",
+        "terraso-backend": "github:techmatters/terraso-backend#2026-06-13.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -15776,7 +15776,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#7fcff697833ecd16e27dc858ba9bfa6d28ebd1c6"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#4b32a981e14cb886ee4cec25fe1899a846f5ef86"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#2026-06-13.0",
+        "terraso-backend": "github:techmatters/terraso-backend#2026-06-17.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^19.2.1",
     "react-redux": "^9.2.0",
-    "terraso-backend": "github:techmatters/terraso-backend#2026-06-13.0",
+    "terraso-backend": "github:techmatters/terraso-backend#2026-06-17.0",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^19.2.1",
     "react-redux": "^9.2.0",
-    "terraso-backend": "github:techmatters/terraso-backend#2026-04-21.0",
+    "terraso-backend": "github:techmatters/terraso-backend#2026-06-13.0",
     "uuid": "^10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Only the pin changes here (`package.json` + `package-lock.json`); the generated `graphqlSchema/` is gitignored.

details:

Bumps the `terraso-backend` pin to **`2026-06-13.0`** 


