### PR TITLE
feat: redux action to delete user + remember email for confirmation message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#2026-06-26.1",
+        "terraso-backend": "github:techmatters/terraso-backend#009699ffd4f18368ad45447195b4bbdad932325f",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -15776,7 +15776,8 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#f415464ed40bb99579dab8cc143db9110f164edd"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#009699ffd4f18368ad45447195b4bbdad932325f",
+      "integrity": "sha512-AuJGajh3JUZjdanJ08zd6DIZEpuh15h40qUQFGJxxdRJDZq9iPLo0sEhnmjeD4gy6fmx8vlVDCUXNhwf+sES6Q=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#009699ffd4f18368ad45447195b4bbdad932325f",
+        "terraso-backend": "github:techmatters/terraso-backend#2026-07-16.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -15776,8 +15776,7 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#009699ffd4f18368ad45447195b4bbdad932325f",
-      "integrity": "sha512-AuJGajh3JUZjdanJ08zd6DIZEpuh15h40qUQFGJxxdRJDZq9iPLo0sEhnmjeD4gy6fmx8vlVDCUXNhwf+sES6Q=="
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#2344d215ab31127c43392b00843a4a0192fae265"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^19.2.1",
     "react-redux": "^9.2.0",
-    "terraso-backend": "github:techmatters/terraso-backend#2026-06-26.1",
+    "terraso-backend": "github:techmatters/terraso-backend#009699ffd4f18368ad45447195b4bbdad932325f",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^19.2.1",
     "react-redux": "^9.2.0",
-    "terraso-backend": "github:techmatters/terraso-backend#009699ffd4f18368ad45447195b4bbdad932325f",
+    "terraso-backend": "github:techmatters/terraso-backend#101e5b5519407a638ae2901a0e7e3e27e4d72348",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^19.2.1",
     "react-redux": "^9.2.0",
-    "terraso-backend": "github:techmatters/terraso-backend#101e5b5519407a638ae2901a0e7e3e27e4d72348",
+    "terraso-backend": "github:techmatters/terraso-backend#2026-07-16.0",
     "uuid": "^10.0.0"
   },
   "scripts": {

--- a/src/account/accountService.ts
+++ b/src/account/accountService.ts
@@ -131,6 +131,63 @@ export const savePreference = async (
   return result.updateUserPreference.preference!;
 };
 
+export type DeletionBlocker = {
+  model: string;
+  qualifier: string | null;
+  field: string;
+  count: number;
+  ids: string[];
+};
+
+export type DeleteUserAccountResult =
+  | { kind: 'deleted'; email: string }
+  | { kind: 'blocked'; blockers: DeletionBlocker[] };
+
+export const deleteUserAccount = async (
+  userId: string,
+  currentUser: User | null,
+): Promise<DeleteUserAccountResult> => {
+  const query = graphql(`
+    mutation deleteUserAccount($input: UserDeleteMutationInput!) {
+      deleteUser(input: $input) {
+        user {
+          ...userFields
+        }
+        blockers {
+          model
+          qualifier
+          field
+          count
+          ids
+        }
+        errors
+      }
+    }
+  `);
+  // Note: when the backend populates `errors` (e.g. the blocked-and-
+  // HubSpot-down case), terrasoApi's handleApiErrors rejects this promise
+  // before we get here. The thunk lands in the .rejected state and the
+  // app's standard error-toast machinery surfaces it. So this resolver
+  // only sees the two success shapes below.
+  const response = await terrasoApi.requestGraphQL(query, {
+    input: { id: userId },
+  });
+  const payload = response.deleteUser;
+
+  if (payload.user) {
+    return { kind: 'deleted', email: currentUser!.email };
+  }
+
+  // `blockers` is typed as `Array<Maybe<BlockerType>>` by codegen but the
+  // backend never returns null entries — drop them so the typed result
+  // matches what callers actually receive.
+  const blockers = (payload.blockers ?? []).filter(
+    (b): b is NonNullable<typeof b> => b !== null,
+  ) as DeletionBlocker[];
+
+  return { kind: 'blocked', blockers };
+};
+
 export const unsubscribeFromNotifications = (token: string) => {
   const query = graphql(`
     mutation unsubscribeUser($input: UserUnsubscribeUpdateInput!) {

--- a/src/account/accountService.ts
+++ b/src/account/accountService.ts
@@ -131,17 +131,9 @@ export const savePreference = async (
   return result.updateUserPreference.preference!;
 };
 
-export type DeletionBlocker = {
-  model: string;
-  qualifier: string | null;
-  field: string;
-  count: number;
-  ids: string[];
-};
-
 export type DeleteUserAccountResult =
   | { kind: 'deleted'; email: string }
-  | { kind: 'blocked'; blockers: DeletionBlocker[] };
+  | { kind: 'blocked' };
 
 export const deleteUserAccount = async (
   userId: string,
@@ -152,13 +144,6 @@ export const deleteUserAccount = async (
       deleteUser(input: $input) {
         user {
           ...userFields
-        }
-        blockers {
-          model
-          qualifier
-          field
-          count
-          ids
         }
         errors
       }
@@ -177,15 +162,7 @@ export const deleteUserAccount = async (
   if (payload.user) {
     return { kind: 'deleted', email: currentUser!.email };
   }
-
-  // `blockers` is typed as `Array<Maybe<BlockerType>>` by codegen but the
-  // backend never returns null entries — drop them so the typed result
-  // matches what callers actually receive.
-  const blockers = (payload.blockers ?? []).filter(
-    (b): b is NonNullable<typeof b> => b !== null,
-  ) as DeletionBlocker[];
-
-  return { kind: 'blocked', blockers };
+  return { kind: 'blocked' };
 };
 
 export const unsubscribeFromNotifications = (token: string) => {

--- a/src/account/accountSlice.ts
+++ b/src/account/accountSlice.ts
@@ -48,6 +48,11 @@ export const initialState = {
     error: null,
   },
   users: {} as Record<string, User>,
+
+  // Used to show a message confirming account deletion on login screen
+  // when automatic account deletion succeeds and the user is being
+  // signed out.
+  accountDeletedEmail: null as string | null,
 };
 
 type AccountState = typeof initialState;
@@ -89,6 +94,12 @@ export const fetchAuthURLs = createAsyncThunk(
 export const savePreference = createAsyncThunk(
   'account/savePreference',
   accountService.savePreference,
+  null,
+  false,
+);
+export const deleteUserAccount = createAsyncThunk(
+  'account/deleteUserAccount',
+  accountService.deleteUserAccount,
   null,
   false,
 );
@@ -136,6 +147,14 @@ export const userSlice = createSlice({
     setHasToken: (state, action: PayloadAction<boolean>) => ({
       ...state,
       hasToken: action.payload,
+    }),
+    setAccountDeletedEmail: (state, action: PayloadAction<string>) => ({
+      ...state,
+      accountDeletedEmail: action.payload,
+    }),
+    clearAccountDeletedEmail: state => ({
+      ...state,
+      accountDeletedEmail: null,
     }),
   },
 
@@ -206,6 +225,27 @@ export const userSlice = createSlice({
         state,
       ),
     );
+
+    // Blocked self-delete: backend set the pending-deletion pref server-side;
+    // mirror it locally so isPending flips without an extra refetch. The
+    // clean-delete branch ('deleted') is handled by the calling hook —
+    // it dispatches userLoggedOut/signOut/setAccountDeletedEmail directly.
+    builder.addCase(deleteUserAccount.fulfilled, (state, action) => {
+      if (action.payload.kind !== 'blocked' || !state.currentUser.data) {
+        return state;
+      }
+      return {
+        ...state,
+        currentUser: {
+          ...state.currentUser,
+          data: _.set(
+            ['preferences', 'account_deletion_request'],
+            'true',
+            state.currentUser.data,
+          ),
+        },
+      };
+    });
 
     builder.addCase(fetchUser.pending, state => ({
       ...state,
@@ -298,7 +338,12 @@ export const userSlice = createSlice({
   },
 });
 
-export const { setCurrentUser, setHasToken } = userSlice.actions;
+export const {
+  setCurrentUser,
+  setHasToken,
+  setAccountDeletedEmail,
+  clearAccountDeletedEmail,
+} = userSlice.actions;
 
 export default userSlice.reducer;
 

--- a/src/account/accountSlice.ts
+++ b/src/account/accountSlice.ts
@@ -64,6 +64,11 @@ export type User = {
   preferences: Record<string, string>;
 };
 
+// Pref that flips to 'true' when the user has requested account deletion but when account can't be auto-deleted
+const ACCOUNT_DELETION_REQUEST_PREF_KEY = 'account_deletion_request';
+export const isAccountDeletionPending = (user: User | null | undefined) =>
+  user?.preferences[ACCOUNT_DELETION_REQUEST_PREF_KEY] === 'true';
+
 export const setHasAccessTokenAsync = createAsyncThunk(
   'account/setHasAccessTokenAsync',
   () => getToken(),
@@ -224,10 +229,12 @@ export const userSlice = createSlice({
       ),
     );
 
-    // Blocked self-delete: backend set the pending-deletion pref server-side; mirror it locally so isPending flips without an extra refetch. The clean-delete branch ('deleted') is handled by the calling hook — it dispatches userLoggedOut/signOut/setAccountDeletedEmail directly.
+    // When there are blockers to auto-deletion: note the backend set the pending-deletion pref server-side; here we mirror it locally so the client doesn't need an extra refetch.
+    // When auto-deletion succeeded, the rest of the behavior is handled by the calling hook.
     builder.addCase(deleteUserAccount.fulfilled, (state, action) => {
       if (action.payload.kind === 'blocked' && state.currentUser.data) {
-        state.currentUser.data.preferences.account_deletion_request = 'true';
+        state.currentUser.data.preferences[ACCOUNT_DELETION_REQUEST_PREF_KEY] =
+          'true';
       }
     });
 

--- a/src/account/accountSlice.ts
+++ b/src/account/accountSlice.ts
@@ -49,9 +49,7 @@ export const initialState = {
   },
   users: {} as Record<string, User>,
 
-  // Used to show a message confirming account deletion on login screen
-  // when automatic account deletion succeeds and the user is being
-  // signed out.
+  // Used to show a message confirming account deletion on login screen when automatic account deletion succeeds and the user is being signed out.
   accountDeletedEmail: null as string | null,
 };
 
@@ -226,25 +224,11 @@ export const userSlice = createSlice({
       ),
     );
 
-    // Blocked self-delete: backend set the pending-deletion pref server-side;
-    // mirror it locally so isPending flips without an extra refetch. The
-    // clean-delete branch ('deleted') is handled by the calling hook —
-    // it dispatches userLoggedOut/signOut/setAccountDeletedEmail directly.
+    // Blocked self-delete: backend set the pending-deletion pref server-side; mirror it locally so isPending flips without an extra refetch. The clean-delete branch ('deleted') is handled by the calling hook — it dispatches userLoggedOut/signOut/setAccountDeletedEmail directly.
     builder.addCase(deleteUserAccount.fulfilled, (state, action) => {
-      if (action.payload.kind !== 'blocked' || !state.currentUser.data) {
-        return state;
+      if (action.payload.kind === 'blocked' && state.currentUser.data) {
+        state.currentUser.data.preferences.account_deletion_request = 'true';
       }
-      return {
-        ...state,
-        currentUser: {
-          ...state.currentUser,
-          data: _.set(
-            ['preferences', 'account_deletion_request'],
-            'true',
-            state.currentUser.data,
-          ),
-        },
-      };
     });
 
     builder.addCase(fetchUser.pending, state => ({


### PR DESCRIPTION
- Add deleteUserAccount action to account slice.
- If it succeeds: Set state variable for deleted email address, so mobile-client can show it on the login screen after account logout and auto-deletion
- If it is blocked: Return blocked
- TODO: Update package.json and package-lock after merging backend PR

### Related Issues
https://github.com/techmatters/terraso-mobile-client/issues/3308

