### PR TITLE
fix: add constant and function to identify deleted user stub

### DIFF
--- a/src/account/authConstants.test.ts
+++ b/src/account/authConstants.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2026 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  DELETED_USER_ID,
+  isDeletedUser,
+} from 'terraso-client-shared/account/authConstants';
+
+// Pinned against terraso-backend's DELETED_USER_ID (apps/core/models/users.py,
+// also asserted in tests/graphql/test_deleted_user_stub.py). If the two drift,
+// clients silently fall back to rendering the stub's English name.
+test('DELETED_USER_ID matches the backend sentinel', () => {
+  expect(DELETED_USER_ID).toBe('00000000-0000-0000-0000-000000000000');
+});
+
+test('isDeletedUser only matches the sentinel', () => {
+  expect(isDeletedUser(DELETED_USER_ID)).toBe(true);
+  expect(isDeletedUser('9f8c1e02-4b7a-4d3e-8f21-6a5b0c7d9e13')).toBe(false);
+  expect(isDeletedUser('')).toBe(false);
+});

--- a/src/account/authConstants.ts
+++ b/src/account/authConstants.ts
@@ -16,3 +16,13 @@
  */
 
 export const UNAUTHENTICATED = 'UNAUTHENTICATED';
+
+// terraso-backend returns an in-memory User stub with this id (and the English
+// name "Deleted User") in place of null when a record's author has been
+// deleted, so the schema's non-null `author` contract still holds. Must
+// stay in sync with DELETED_USER_ID in apps/core/models/users.py; drift is
+// silent, so both sides pin the literal in a test.
+export const DELETED_USER_ID = '00000000-0000-0000-0000-000000000000';
+
+// Callers substitute their own localized label — the stub's name is English.
+export const isDeletedUser = (id: string) => id === DELETED_USER_ID;


### PR DESCRIPTION
## Description
To enable localized deleted user attribute on site note, define the id of the stub user (same as what the backend defines)

### Related Issues
https://github.com/techmatters/terraso-mobile-client/issues/3308#issuecomment-5106974719