### PR TITLE
feat: output ESM instead of CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "terraso-client-shared",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "sideEffects": [
     "src/tests/config.ts"
   ],
@@ -124,7 +125,12 @@
   },
   "babel": {
     "presets": [
-      "@babel/preset-env",
+      [
+        "@babel/preset-env",
+        {
+          "modules": false
+        }
+      ],
       "@babel/preset-typescript",
       "@babel/preset-react"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
 
-
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
-    "module": "node16",
+    "module": "esnext",
     "target": "es2015",
 
     "allowJs": false,
@@ -13,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "moduleResolution": "node16",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Description
Needed for https://github.com/techmatters/terraso-web-client/pull/2994. Needs a small companion PR for mobile client Jest changes, but no expected issues in either environment.
